### PR TITLE
Configure releases

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -98,15 +98,6 @@ afterEvaluate {
                 artifactId = 'final'
                 version = '1.0'
             }
-            // Creates a Maven publication called “debug”.
-            debug(MavenPublication) {
-                // Applies the component for the debug build variant.
-                from components.debug
-
-                groupId = 'com.telemetrydeck.sdk'
-                artifactId = 'final-debug'
-                version = '1.0'
-            }
         }
     }
 }


### PR DESCRIPTION
Hi @winsmith,

This PR cleans the release definitions so the library can be imported as a dependency like:

```
implementation 'com.github.kkostov:KotlinSDK:e592ffd5edb1f82a188b70f737ade23065abd5cc'
```

Once there are release tags in https://github.com/TelemetryDeck/KotlinSDK this can be improved to

```
implementation 'com.github.TelemetryDeck:1.0.0'
```

cf https://docs.jitpack.io/
