### PR TITLE
Bugfix/catch ktor exceptions

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -96,7 +96,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'com.telemetrydeck.sdk'
                 artifactId = 'final'
-                version = '1.0'
+                version = '1.1'
             }
         }
     }

--- a/lib/src/main/java/com/telemetrydeck/sdk/Signal.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/Signal.kt
@@ -9,7 +9,7 @@ data class Signal(
      * When was this signal generated
      */
     @Serializable(with = DateSerializer::class)
-    var receivedAt: Date? = null,
+    var receivedAt: Date = Date(),
 
     /**
      * The App ID of this signal

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryBroadcastTimer.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryBroadcastTimer.kt
@@ -32,7 +32,13 @@ internal class TelemetryBroadcastTimer(private val manager: WeakReference<Teleme
                     }
 
                     logger?.debug("Broadcasting ${signals.count()} queued signals")
-                    managerInstance.send(signals)
+                    val success = managerInstance.send(signals)
+                    if (!success) {
+                        logger?.debug("Re-enqueueing ${signals.count()} signals")
+                        for (failedSignal in signals) {
+                            managerInstance.cache?.add(failedSignal)
+                        }
+                    }
                 }
             }
         }

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManager.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManager.kt
@@ -7,6 +7,8 @@ import java.lang.ref.WeakReference
 import java.net.URL
 import java.security.MessageDigest
 import java.util.*
+import kotlin.Result.Companion.failure
+import kotlin.Result.Companion.success
 
 
 class TelemetryManager(
@@ -47,27 +49,27 @@ class TelemetryManager(
         signalType: String,
         clientUser: String?,
         additionalPayload: Map<String, String>
-    ) {
-        send(createSignal(signalType, clientUser, additionalPayload))
+    ): Result<Unit> {
+        return send(createSignal(signalType, clientUser, additionalPayload))
     }
 
     override suspend fun send(
         signalType: SignalType,
         clientUser: String?,
         additionalPayload: Map<String, String>
-    ) {
-        send(signalType.type, clientUser, additionalPayload)
+    ): Result<Unit> {
+        return send(signalType.type, clientUser, additionalPayload)
     }
 
     suspend fun send(
         signal: Signal
-    ) {
-        send(listOf(signal))
+    ): Result<Unit> {
+        return send(listOf(signal))
     }
 
     suspend fun send(
         signals: List<Signal>
-    ): Boolean {
+    ): Result<Unit> {
         return try {
             val client = TelemetryClient(
                 configuration.telemetryAppID,
@@ -76,10 +78,10 @@ class TelemetryManager(
                 logger
             )
             client.send(signals)
-            true
+            success(Unit)
         } catch(e: Exception) {
             logger?.error("Failed to send signals due to an error ${e} ${e.stackTraceToString()}")
-            false
+            failure(e)
         }
     }
 
@@ -208,16 +210,24 @@ class TelemetryManager(
             signalType: String,
             clientUser: String?,
             additionalPayload: Map<String, String>
-        ) {
-            getInstance()?.send(signalType, clientUser, additionalPayload)
+        ): Result<Unit> {
+            val result = getInstance()?.send(signalType, clientUser, additionalPayload)
+            if (result != null) {
+                return result
+            }
+            return failure(NullPointerException())
         }
 
         override suspend fun send(
             signalType: SignalType,
             clientUser: String?,
             additionalPayload: Map<String, String>
-        ) {
-            getInstance()?.send(signalType, clientUser, additionalPayload)
+        ): Result<Unit> {
+            val result = getInstance()?.send(signalType, clientUser, additionalPayload)
+            if (result != null) {
+                return result
+            }
+            return failure(NullPointerException())
         }
     }
 

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManager.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManager.kt
@@ -67,14 +67,20 @@ class TelemetryManager(
 
     suspend fun send(
         signals: List<Signal>
-    ) {
-        val client = TelemetryClient(
-            configuration.telemetryAppID,
-            configuration.apiBaseURL,
-            configuration.showDebugLogs,
-            logger
-        )
-        client.send(signals)
+    ): Boolean {
+        return try {
+            val client = TelemetryClient(
+                configuration.telemetryAppID,
+                configuration.apiBaseURL,
+                configuration.showDebugLogs,
+                logger
+            )
+            client.send(signals)
+            true
+        } catch(e: Exception) {
+            logger?.error("Failed to send signals due to an error ${e} ${e.stackTraceToString()}")
+            false
+        }
     }
 
     internal var broadcastTimer: TelemetryBroadcastTimer? = null

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManagerSignals.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManagerSignals.kt
@@ -46,7 +46,7 @@ interface TelemetryManagerSignals {
         signalType: String,
         clientUser: String? = null,
         additionalPayload: Map<String, String> = emptyMap()
-    )
+    ): Result<Unit>
 
 
     /**
@@ -56,5 +56,5 @@ interface TelemetryManagerSignals {
         signalType: SignalType,
         clientUser: String? = null,
         additionalPayload: Map<String, String> = emptyMap()
-    )
+    ): Result<Unit>
 }

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryManagerTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryManagerTest.kt
@@ -5,8 +5,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.*
-import org.mockito.kotlin.verify
 import java.net.URL
 import java.util.*
 
@@ -220,6 +218,21 @@ class TelemetryManagerTest {
             .build(null)
 
         Assert.assertTrue(provider.registered)
+    }
+
+    @Test
+    fun telemetryBroadcastTimer_can_filter_older_signals() {
+        // an old signal is received longer than 24h ago
+        val okSignal = Signal(appID = UUID.randomUUID(), "okSignal", "user", SignalPayload())
+        val oldSignal = Signal(appID = UUID.randomUUID(), "oldSignal", "user", SignalPayload())
+        val calendar = Calendar.getInstance()
+        calendar.add(Calendar.DAY_OF_YEAR, -2)
+        oldSignal.receivedAt = calendar.time
+
+        val filteredSignals = TelemetryBroadcastTimer.filterOldSignals(listOf(okSignal, oldSignal))
+
+        Assert.assertEquals(1, filteredSignals.count())
+        Assert.assertEquals("okSignal", filteredSignals[0].type)
     }
 }
 


### PR DESCRIPTION
In some situations, it is not possible to submit signals successfully. For example, in cases where no internet connection is available, or the device's connectivity is otherwise restricted.

This PR introduces the following changes:

* TelemetryManager now catches exceptions for network operations. Methods for sending signals now return a `Result<Unit>` which allows the caller to determine how to handle the problem. This should help with #4. 

* The library version has been bumped to `1.1` due to a non-breaking API change in the public TelemetryManager interface.

* `TelemetryBroadcastTimer` now detects send failures and re-enqueues the failed signals for later broadcast.

* All signals are now initialised with the current date and time.

* `TelemetryBroadcastTimer` now discards signals older than 24h.
