### PR TITLE
Allow build on Android API >= 21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.telemetrydeck.sdk.app"
-        minSdk 24
+        minSdk 21
         targetSdk 31
         versionCode 1
         versionName "1.0"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        minSdk 24
+        minSdk 21
         targetSdk 31
         versionCode 1
         versionName "1.0"

--- a/lib/src/main/java/com/telemetrydeck/sdk/EnvironmentMetadataProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/EnvironmentMetadataProvider.kt
@@ -29,9 +29,15 @@ class EnvironmentMetadataProvider : TelemetryProvider {
             val sdkVersion = android.os.Build.VERSION.SDK_INT
             metadata["systemVersion"] = "Android SDK: $sdkVersion ($release)"
 
-            val versionInfo = VersionInfo.getInstance(release)
-            metadata["majorSystemVersion"] = versionInfo.major.toString()
-            metadata["majorMinorSystemVersion"] = "${versionInfo.major}.${versionInfo.minor}"
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                val versionInfo = VersionInfo.getInstance(release)
+                metadata["majorSystemVersion"] = versionInfo.major.toString()
+                metadata["majorMinorSystemVersion"] = "${versionInfo.major}.${versionInfo.minor}"
+            } else {
+                val versionInfo = release.split(".")
+                metadata["majorSystemVersion"] = versionInfo.elementAtOrNull(0) ?: "0"
+                metadata["majorMinorSystemVersion"] = "${versionInfo.elementAtOrNull(0) ?: "0"}.${versionInfo.elementAtOrNull(1) ?: "0"}"
+            }
         }
 
         metadata["locale"] = Locale.getDefault().displayName


### PR DESCRIPTION
Following on https://github.com/TelemetryDeck/KotlinSDK/issues/8, this seems to do the trick. I have not been able to test on Android API 21-23 since I don't have such a device on hand at the moment and emulators on M1 Mac don't exist before API 28 as far as I know.