### PR TITLE
Environment provider should allow clients to set environment values

### DIFF
--- a/lib/src/main/java/com/telemetrydeck/sdk/EnvironmentMetadataProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/EnvironmentMetadataProvider.kt
@@ -67,7 +67,9 @@ class EnvironmentMetadataProvider : TelemetryProvider {
     ): Map<String, String> {
         val signalPayload = additionalPayload.toMutableMap()
         for (item in metadata) {
-            signalPayload[item.key] = item.value
+            if (!signalPayload.containsKey(item.key)) {
+                signalPayload[item.key] = item.value
+            }
         }
         return signalPayload
     }

--- a/lib/src/test/java/com/telemetrydeck/sdk/EnvironmentMetadataProviderTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/EnvironmentMetadataProviderTest.kt
@@ -1,0 +1,40 @@
+package com.telemetrydeck.sdk
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.util.UUID
+
+class EnvironmentMetadataProviderTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun environmentMetadataProvider_sets_client_version() {
+        val appID = "32CB6574-6732-4238-879F-582FEBEB6536"
+        val config = TelemetryManagerConfiguration(appID)
+        val manager =  TelemetryManager.Builder().configuration(config).build(null)
+
+        manager.queue("type", "clientUser", emptyMap())
+
+        val queuedSignal = manager.cache?.empty()?.first()
+
+        Assert.assertNotNull(queuedSignal)
+        Assert.assertEquals(queuedSignal?.payload?.contains("telemetryClientVersion:com.telemetrydeck.sdk"), true)
+    }
+
+    @Test
+    fun environmentMetadataProvider_allows_properties_to_be_set_in_advance() {
+        val appID = "32CB6574-6732-4238-879F-582FEBEB6536"
+        val config = TelemetryManagerConfiguration(appID)
+        val manager =  TelemetryManager.Builder().configuration(config).build(null)
+
+        manager.queue("type", "clientUser", mapOf("telemetryClientVersion" to "my value"))
+
+        val queuedSignal = manager.cache?.empty()?.first()
+
+        Assert.assertNotNull(queuedSignal)
+        Assert.assertEquals(queuedSignal?.payload?.contains("telemetryClientVersion:my value"), true)
+    }
+}


### PR DESCRIPTION
This PR changes the behaviour of the default EnvironmentMetadataProvider so that if an environment value is already set in a signal payload, it will not be overwritten.

We need this for the Flutter SDK where the flutter layer (or the user) will set some client version information.

In the iOS SDK this is known as precedence: https://github.com/TelemetryDeck/SwiftClient/blob/main/Tests/TelemetryClientTests/TelemetryClientTests.swift#L77

It will be up to every `TelemetryProvider` to implement the desired behaviour. 