### PR TITLE
Fix jitpack release

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+# https://jitpack.io/docs/BUILDING/#custom-commands
+jdk:
+  - openjdk17

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -97,7 +97,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'com.telemetrydeck.sdk'
                 artifactId = 'final'
-                version = '1.1'
+                version = '2.0'
             }
         }
     }


### PR DESCRIPTION
It seems the latest version has failed to publish https://jitpack.io/#TelemetryDeck/KotlinSDK

Build log: https://jitpack.io/com/github/TelemetryDeck/KotlinSDK/2.0.0/build.log