### PR TITLE
isTestMode should be a string in v1

### DIFF
--- a/lib/src/main/java/com/telemetrydeck/sdk/Signal.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/Signal.kt
@@ -43,7 +43,7 @@ data class Signal(
     /**
      * If "true", mark the signal as a testing signal and only show it in a dedicated test mode UI
      */
-    var isTestMode: Boolean = false
+    var isTestMode: String = "false"
 ) {
     constructor(appID: UUID, signalType: String, clientUser: String, payload: SignalPayload) : this(appID=appID, type=signalType, clientUser = clientUser, payload = payload.asMultiValueDimension)
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManager.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManager.kt
@@ -112,7 +112,7 @@ class TelemetryManager(
             type = signalType,
             clientUser = hashedUser,
             payload = payload.asMultiValueDimension,
-            isTestMode = configuration.testMode
+            isTestMode = configuration.testMode.toString().lowercase()
         )
         signal.sessionID = this.configuration.sessionID.toString()
         logger?.debug("Created a signal ${signal.type}, session ${signal.sessionID}, test ${signal.isTestMode}")

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryManagerTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryManagerTest.kt
@@ -28,7 +28,7 @@ class TelemetryManagerTest {
         Assert.assertEquals(config.sessionID, UUID.fromString(queuedSignal.sessionID))
         Assert.assertEquals("type", queuedSignal.type)
         Assert.assertEquals("6721870580401922549fe8fdb09a064dba5b8792fa018d3bd9ffa90fe37a0149", queuedSignal.clientUser)
-        Assert.assertEquals(false, queuedSignal.isTestMode)
+        Assert.assertEquals("false", queuedSignal.isTestMode)
     }
 
     @Test
@@ -190,7 +190,7 @@ class TelemetryManagerTest {
             .build(null)
         sut.queue("type")
 
-        Assert.assertEquals(true, sut.cache?.empty()?.get(0)?.isTestMode)
+        Assert.assertEquals("true", sut.cache?.empty()?.get(0)?.isTestMode)
     }
 
     @Test
@@ -202,7 +202,7 @@ class TelemetryManagerTest {
             .build(null)
         sut.queue("type")
 
-        Assert.assertEquals(false, sut.cache?.empty()?.get(0)?.isTestMode)
+        Assert.assertEquals("false", sut.cache?.empty()?.get(0)?.isTestMode)
     }
 
     @Test


### PR DESCRIPTION
This PR changes isTestMode to a string. 

This should address https://github.com/TelemetryDeck/FlutterSDK/issues/6