### PR TITLE
Fix use of custom user salt when hashing the client id

### DIFF
--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManager.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryManager.kt
@@ -105,7 +105,7 @@ class TelemetryManager(
         }
         val userValue = clientUser ?: configuration.defaultUser ?: ""
         val userValueWithSalt = userValue +( configuration.salt ?: "")
-        val hashedUser = hashString(userValue, "SHA-256")
+        val hashedUser = hashString(userValueWithSalt, "SHA-256")
         val payload = SignalPayload(additionalPayload = enrichedPayload)
         val signal = Signal(
             appID = configuration.telemetryAppID,

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryManagerTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryManagerTest.kt
@@ -32,6 +32,17 @@ class TelemetryManagerTest {
     }
 
     @Test
+    fun telemetryManager_applies_custom_salt() {
+        val appID = "32CB6574-6732-4238-879F-582FEBEB6536"
+        val config = TelemetryManagerConfiguration(appID)
+        config.salt = "my salt"
+        val manager =  TelemetryManager.Builder().configuration(config).build(null)
+        manager.queue("type", "clientUser", emptyMap())
+        val queuedSignal = manager.cache?.empty()?.first()
+        Assert.assertEquals("9a68a3790deb1db66f80855b8e7c5a97df8002ef90d3039f9e16c94cfbd11d99", queuedSignal?.clientUser)
+    }
+
+    @Test
     fun telemetryManager_builder_set_configuration() {
         val appID = "32CB6574-6732-4238-879F-582FEBEB6536"
         val config = TelemetryManagerConfiguration(appID)


### PR DESCRIPTION
This PR addresses a defect where the library will ignore a custom hashing salt for the client id if one was provided.

Note: After adopting a version of the SDK including this fix, users already specifying a custom salt will see a change in the generated clientId hash which may influence some statistics.