### PR TITLE
Fix possible crash when the cache directory doesn't exist

### DIFF
--- a/lib/src/main/java/com/telemetrydeck/sdk/PersistentSignalCache.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/PersistentSignalCache.kt
@@ -56,6 +56,8 @@ class PersistentSignalCache(private var signalQueue: MutableList<Signal> = mutab
     }
 
     private fun saveSignals() {
+        // make sure the parent folder exists before writing
+        file?.parentFile?.mkdirs()
         file?.createNewFile()
         val json = Json.encodeToString(signalQueue)
         file?.writeText(json)


### PR DESCRIPTION
This PR addresses #24 by making sure the directory where we write the persistent signal cache already exists.
