### PR TITLE
[#14] Autogenerate user identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,34 @@ To enqueue a signal to be sent by TelemetryDeck at a later time
 TelemetryDeck.signal("appLaunchedRegularly")
 ```
 
+## User Identifiers
+
+When `TelemetryDeck` is started for the first time, it will create a user identifier for the user that is specific to the app installation.
+
+* The identity is stored within the application's file folder on the user's device. 
+
+* The identifier will be removed when a user uninstalls an app. The KotlinSDK will not "bridge" the user's identity between installations.
+
+* Users can reset the identifier at any time by using the "Clear Data" action in Settings of their device.
+
+If you have a better user identifier available, such as an email address or a username, you can use that instead, by setting `defaultUser` (the identifier will be hashed before sending it) in configuration, or by passing the value when sending signals.
+
+
+### Custom User Identifiers
+
+If you need a more robust mechanism for keep track of the user's identity, you can replace the default behaviour by providing your own implementation of `TelemetryDeckIdentityProvider`:
+
+```kotlin
+val builder = TelemetryDeck.Builder()
+            .appID("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
+            .showDebugLogs(true)
+            .defaultUser("Person")
+            .identityProvider(YourIdentityProvider())
+
+TelemetryDeck.start(application, builder)
+```
+
+
 ### Environment Parameters
 
 By default, Kotlin SDK for TelemetryDeck will include the following environment parameters for each outgoing signal

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ TelemetryDeck.signal("appLaunchedRegularly")
 By default, Kotlin SDK for TelemetryDeck will include the following environment parameters for each outgoing signal
 
 
-| Signal name                                    | Provider                       |
+| Parameter name                                 | Provider                       |
 |------------------------------------------------|--------------------------------|
 | `TelemetryDeck.Session.started`                | `SessionAppProvider`           |
 | `TelemetryDeck.AppInfo.buildNumber`            | `EnvironmentParameterProvider` |

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/FileUserIdentityProviderTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/FileUserIdentityProviderTest.kt
@@ -1,0 +1,77 @@
+package com.telemetrydeck.sdk
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.telemetrydeck.sdk.providers.FileUserIdentityProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class FileUserIdentityProviderTest {
+
+    private fun createSut(): FileUserIdentityProvider {
+        val appContext = ApplicationProvider.getApplicationContext<Application>()
+        val sut = FileUserIdentityProvider()
+        sut.register(appContext, TelemetryDeck(configuration = TelemetryManagerConfiguration("32CB6574-6732-4238-879F-582FEBEB6536"), providers = emptyList()))
+        return sut
+    }
+
+    private fun prepareIdentity(value: String) {
+        val appContext = ApplicationProvider.getApplicationContext<Application>()
+        val file = File(appContext.filesDir, "telemetrydeckid")
+        file.writeText(value)
+    }
+
+    @Test
+    fun providesConfigUserIdentity() {
+        prepareIdentity("1851B82D-3D39-469D-BED4-19E69C09AF49")
+
+        val sut = createSut()
+        val result = sut.calculateIdentity(null, "default user id")
+        assertEquals("default user id", result)
+    }
+
+    @Test
+    fun prefersSignalIdWhenProvided() {
+        prepareIdentity("1851B82D-3D39-469D-BED4-19E69C09AF49")
+
+        val sut = createSut()
+        val result = sut.calculateIdentity("signal id", "default user id")
+        assertEquals("signal id", result)
+    }
+
+    @Test
+    fun usesDefaultUserIdentityWhenSignalAndConfigIsNull() {
+        prepareIdentity("1851B82D-3D39-469D-BED4-19E69C09AF49")
+
+        val sut = createSut()
+        val result = sut.calculateIdentity(null, null)
+        assertEquals("1851B82D-3D39-469D-BED4-19E69C09AF49", result)
+    }
+
+    @Test
+    fun createsStableUserIdentity() {
+        val sut1 = createSut()
+        val first_result = sut1.calculateIdentity(null, null)
+        assert(!first_result.isBlank())
+
+        val sut2 = createSut()
+        val second_result = sut2.calculateIdentity(null, null)
+        assertEquals(first_result, second_result)
+    }
+
+    @Test
+    fun resetsStableUserIdentity() {
+        val sut1 = createSut()
+        val first_result = sut1.calculateIdentity(null, null)
+        sut1.resetIdentity()
+
+        val sut2 = createSut()
+        val second_result = sut2.calculateIdentity(null, null)
+        assertNotEquals(first_result, second_result)
+    }
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckIdentityProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckIdentityProvider.kt
@@ -1,0 +1,33 @@
+package com.telemetrydeck.sdk
+
+import android.app.Application
+
+/**
+ * Generic interface for plugins which can calculate anonymous user identifier
+ */
+interface TelemetryDeckIdentityProvider {
+    /**
+     * Registers the provider with the telemetry manager.
+     */
+    fun register(ctx: Application?, client: TelemetryDeckSignalProcessor)
+
+    /**
+     * Calling stop deactivates the provider, performs any cleanup work if necessary.
+     */
+    fun stop()
+
+
+    /**
+     * Calculate the user identifier to be attached to a signal.
+     *
+     * @param[signalClientUser] The existing `clientUser` value of the signal (if any has been provided).
+     * @param[configurationDefaultUser] The default user value from the [TelemetryDeck] configuration (if any has been provided).
+     * @return the user identifier to be associated with the outgoing signal.
+     */
+    fun calculateIdentity(signalClientUser: String?, configurationDefaultUser: String?): String
+
+    /**
+     * Permanently removes any persisted user identifier.
+     */
+    fun resetIdentity()
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/FileUserIdentityProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/FileUserIdentityProvider.kt
@@ -1,0 +1,71 @@
+package com.telemetrydeck.sdk.providers
+
+import android.app.Application
+import com.telemetrydeck.sdk.TelemetryDeckIdentityProvider
+import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
+import java.io.File
+import java.lang.ref.WeakReference
+import java.util.UUID
+
+/**
+ * [FileUserIdentityProvider] attempts to provide a stable user identifier across multiple sessions.
+ *
+ * When no user identifier has been provided to [com.telemetrydeck.sdk.TelemetryDeck], [FileUserIdentityProvider] uses a file
+ * in the application's folder to store a randomly generated user identifier.
+ *
+ * The identifier will be removed when a user uninstalls an app. The KotlinSDK will not "bridge" the user's identity between installations.
+ * Users can reset the identifier at any time by using the "Clear Data" action in Settings of their device.
+ *
+ *
+ * */
+class FileUserIdentityProvider: TelemetryDeckIdentityProvider {
+    private var app: WeakReference<Application?>? = null
+    private var manager: WeakReference<TelemetryDeckSignalProcessor>? = null
+    private val fileName = "telemetrydeckid"
+    private val fileEncoding = Charsets.UTF_8
+
+    override fun register(ctx: Application?, client: TelemetryDeckSignalProcessor) {
+        this.app = WeakReference(ctx)
+        this.manager = WeakReference(client)
+    }
+
+    override fun stop() {
+        // nothing to do here
+    }
+
+    override fun calculateIdentity(signalClientUser: String?, configurationDefaultUser: String?): String {
+        val simpleValue = signalClientUser ?: configurationDefaultUser ?: readOrCreateStableIdentity() ?: ""
+        return simpleValue
+    }
+
+    override fun resetIdentity() {
+        // to reset, we delete the identity file if it exists
+        val context = this.app?.get()?.applicationContext ?: return
+        val file = File(context.filesDir, fileName)
+        try {
+            if (file.exists()) {
+                file.delete()
+            }
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+    }
+
+    private fun readOrCreateStableIdentity(): String? {
+        val context = this.app?.get()?.applicationContext ?: return null
+
+        try {
+            val file = File(context.filesDir, fileName)
+            if (!file.exists()) {
+                val newId = UUID.randomUUID().toString()
+                file.writeText(newId, fileEncoding)
+                return newId
+            }
+
+            return file.readText(fileEncoding)
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+            return null
+        }
+    }
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/PlatformContextProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/PlatformContextProvider.kt
@@ -1,7 +1,6 @@
 package com.telemetrydeck.sdk.providers
 
 import android.app.Application
-import android.content.Context
 import com.telemetrydeck.sdk.TelemetryDeckProvider
 import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
 import com.telemetrydeck.sdk.TelemetryProviderFallback
@@ -17,7 +16,7 @@ import java.lang.ref.WeakReference
 internal class PlatformContextProvider : TelemetryDeckProvider, TelemetryProviderFallback {
     private var enabled: Boolean = true
     private var manager: WeakReference<TelemetryDeckSignalProcessor>? = null
-    private var appContext: WeakReference<Context?>? = null
+    private var appContext: WeakReference<Application?>? = null
     private var metadata = mutableMapOf<String, String>()
 
     override fun fallbackRegister(ctx: Application?, client: TelemetryDeckSignalProcessor) {
@@ -30,7 +29,7 @@ internal class PlatformContextProvider : TelemetryDeckProvider, TelemetryProvide
 
     override fun register(ctx: Application?, client: TelemetryDeckSignalProcessor) {
         this.manager = WeakReference(client)
-        this.appContext = WeakReference(ctx?.applicationContext)
+        this.appContext = WeakReference(ctx)
 
         if (ctx == null) {
             this.manager?.get()?.debugLogger?.error("RunContextProvider requires a context but received null. Signals will contain incomplete metadata.")
@@ -91,7 +90,7 @@ internal class PlatformContextProvider : TelemetryDeckProvider, TelemetryProvide
     // TODO: Use onConfigurationChanged instead
 
     private fun getDynamicAttributes(): Map<String, String> {
-        val ctx = this.appContext?.get()
+        val ctx = this.appContext?.get()?.applicationContext
             ?: // can't read without a context!
             return emptyMap()
 


### PR DESCRIPTION
This PR fixes #14 by introducing a mechanism to automatically persist an anonymous identifier of the user's identity when none has been supplied via configuration.