### PR TITLE
[#41] Send the correct library version for outgoing signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Kotlin SDK for TelemetryDeck is available from Maven Central and can be used
 
 ```groovy
 dependencies {
-    implementation 'com.telemetrydeck:kotlin-sdk:3.0.3'
+    implementation 'com.telemetrydeck:kotlin-sdk:3.0.4'
 }
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,9 @@
 ## Releasing a new version of the library
 
-1. Update the library coordinates by incrementing the version in https://github.com/TelemetryDeck/KotlinSDK/blob/lib/build.gradle.kts#L103.
-2. Update the README.md to instruct new users to use the latest version.
-3. Commit and push.
+1. Update the library coordinates by incrementing the version in https://github.com/TelemetryDeck/KotlinSDK/blob/lib/build.gradle.kts#L104.
+2. Update the `sdkVersion` in `EnvironmentParameterProvider`
+3. Update the README.md to instruct new users to use the latest version.
+4. Commit and push.
 
 ### Publishing using GitHub Actions
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -101,7 +101,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.telemetrydeck", "kotlin-sdk", "3.0.3")
+    coordinates("com.telemetrydeck", "kotlin-sdk", "3.0.4")
 
     pom {
         name = "TelemetryDeck SDK"

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
@@ -30,6 +30,7 @@ internal class EnvironmentParameterProvider : TelemetryDeckProvider, TelemetryPr
     private val platform: String = "Android"
     private val os: String = "Android"
     private val sdkName: String = "KotlinSDK"
+    private val sdkVersion: String = "3.0.4"
 
     override fun fallbackRegister(ctx: Application?, client: TelemetryDeckSignalProcessor) {
         register(ctx, client)
@@ -49,8 +50,8 @@ internal class EnvironmentParameterProvider : TelemetryDeckProvider, TelemetryPr
 
     private fun appendSDKMetadata() {
         metadata[SDK.Name.paramName] = sdkName
-        metadata[SDK.Version.paramName] = BuildConfig.LIBRARY_PACKAGE_NAME
-        metadata[SDK.NameAndVersion.paramName] = "$sdkName ${BuildConfig.LIBRARY_PACKAGE_NAME}"
+        metadata[SDK.Version.paramName] = sdkVersion
+        metadata[SDK.NameAndVersion.paramName] = "$sdkName $sdkVersion"
         metadata[SDK.BuildType.paramName] = BuildConfig.BUILD_TYPE
     }
 


### PR DESCRIPTION
This PR fixes #41 by correctly setting the library version for parameter `TelemetryDeck.SDK.version` and `TelemetryDeck.SDK.nameAndVersion`