### PR TITLE
Automatically include accessibility stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,8 @@ By default, Kotlin SDK for TelemetryDeck will include the following environment 
 | `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`     | `AccessibilityProvider`        |                                                                                        |
 | `TelemetryDeck.Accessibility.fontScale`                       | `AccessibilityProvider`        |                                                                                        |
 | `TelemetryDeck.Accessibility.isInvertColorsEnabled`           | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.isVoiceOverEnabled`              | `AccessibilityProvider`        |                                                                                        |
 | `TelemetryDeck.Accessibility.isReduceMotionEnabled`           | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.isAccessibilityButtonSupported`  | `AccessibilityProvider`        | if the accessibility button within the system navigation area is supported             |
-| `TelemetryDeck.Accessibility.isAudioDescriptionRequested`     | `AccessibilityProvider`        | if users want to select soundtrack with audio description by default                   |
 | `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`     | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.isSwitchControlEnabled`          | `AccessibilityProvider`        |                                                                                        |
 | `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` | `AccessibilityProvider`        |                                                                                        |
 | `TelemetryDeck.UserPreference.layoutDirection`                | `AccessibilityProvider`        | Possible values are "rightToLeft" or "leftToRight"                                     |
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,13 @@ TelemetryDeck.signal("appLaunchedRegularly")
 
 When `TelemetryDeck` is started for the first time, it will create a user identifier for the user that is specific to the app installation.
 
-* The identity is stored within the application's file folder on the user's device. 
+- The identity is stored within the application's file folder on the user's device.
 
-* The identifier will be removed when a user uninstalls an app. The KotlinSDK will not "bridge" the user's identity between installations.
+- The identifier will be removed when a user uninstalls an app. The KotlinSDK will not "bridge" the user's identity between installations.
 
-* Users can reset the identifier at any time by using the "Clear Data" action in Settings of their device.
+- Users can reset the identifier at any time by using the "Clear Data" action in Settings of their device.
 
 If you have a better user identifier available, such as an email address or a username, you can use that instead, by setting `defaultUser` (the identifier will be hashed before sending it) in configuration, or by passing the value when sending signals.
-
 
 ### Custom User Identifiers
 
@@ -108,43 +107,54 @@ val builder = TelemetryDeck.Builder()
 TelemetryDeck.start(application, builder)
 ```
 
-
 ### Environment Parameters
 
 By default, Kotlin SDK for TelemetryDeck will include the following environment parameters for each outgoing signal
 
-
-| Parameter name                                 | Provider                       |
-|------------------------------------------------|--------------------------------|
-| `TelemetryDeck.Session.started`                | `SessionAppProvider`           |
-| `TelemetryDeck.AppInfo.buildNumber`            | `EnvironmentParameterProvider` |
-| `TelemetryDeck.AppInfo.version`                | `EnvironmentParameterProvider` |
-| `TelemetryDeck.AppInfo.versionAndBuildNumber`  | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.architecture`            | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.modelName`               | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.operatingSystem`         | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.platform`                | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.systemMajorMinorVersion` | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.systemMajorVersion`      | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.systemVersion`           | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.orientation`             | `PlatformContextProvider`      |
-| `TelemetryDeck.Device.screenDensity`           | `PlatformContextProvider`      |
-| `TelemetryDeck.Device.screenResolutionHeight`  | `PlatformContextProvider`      |
-| `TelemetryDeck.Device.screenResolutionWidth`   | `PlatformContextProvider`      |
-| `TelemetryDeck.Device.brand`                   | `EnvironmentParameterProvider` |
-| `TelemetryDeck.Device.timeZone`                | `PlatformContextProvider`      |
-| `TelemetryDeck.AppInfo.buildNumber`            | `EnvironmentParameterProvider` |
-| `TelemetryDeck.AppInfo.version`                | `EnvironmentParameterProvider` |
-| `TelemetryDeck.AppInfo.versionAndBuildNumber`  | `EnvironmentParameterProvider` |
-| `TelemetryDeck.SDK.name`                       | `EnvironmentParameterProvider` |
-| `TelemetryDeck.SDK.version`                    | `EnvironmentParameterProvider` |
-| `TelemetryDeck.SDK.nameAndVersion`             | `EnvironmentParameterProvider` |
-| `TelemetryDeck.SDK.buildType`                  | `EnvironmentParameterProvider` |
-| `TelemetryDeck.RunContext.locale`              | `PlatformContextProvider`      |
-| `TelemetryDeck.RunContext.targetEnvironment`   | `PlatformContextProvider`      |
-| `TelemetryDeck.RunContext.isSideLoaded`        | `PlatformContextProvider`      |
-| `TelemetryDeck.RunContext.sourceMarketplace`   | `PlatformContextProvider`      |
-
+| Parameter name                                                | Provider                       | Description                                                                            |
+| ------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------- |
+| `TelemetryDeck.Session.started`                               | `SessionAppProvider`           |                                                                                        |
+| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.architecture`                           | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.modelName`                              | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.operatingSystem`                        | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.platform`                               | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.systemMajorMinorVersion`                | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.systemMajorVersion`                     | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.systemVersion`                          | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.orientation`                            | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.Device.screenDensity`                          | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.Device.screenResolutionHeight`                 | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.Device.screenResolutionWidth`                  | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.Device.brand`                                  | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.Device.timeZone`                               | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.SDK.name`                                      | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.SDK.version`                                   | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.SDK.nameAndVersion`                            | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.SDK.buildType`                                 | `EnvironmentParameterProvider` |                                                                                        |
+| `TelemetryDeck.RunContext.locale`                             | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.RunContext.targetEnvironment`                  | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.RunContext.isSideLoaded`                       | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.RunContext.sourceMarketplace`                  | `PlatformContextProvider`      |                                                                                        |
+| `TelemetryDeck.Device.isAccessibilityButtonSupported`         | `AccessibilityProvider`        | if the accessibility button within the system navigation area is supported             |
+| `TelemetryDeck.Accessibility.isBoldTextEnabled`               | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.Accessibility.fontWeightAdjustment`            | `AccessibilityProvider`        | the amount of font weight adjustment or the value equals 0 if no adjustment is applied |
+| `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`     | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.Accessibility.fontScale`                       | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.Accessibility.isInvertColorsEnabled`           | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.Accessibility.isVoiceOverEnabled`              | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.Accessibility.isReduceMotionEnabled`           | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.Accessibility.isAccessibilityButtonSupported`  | `AccessibilityProvider`        | if the accessibility button within the system navigation area is supported             |
+| `TelemetryDeck.Accessibility.isAudioDescriptionRequested`     | `AccessibilityProvider`        | if users want to select soundtrack with audio description by default                   |
+| `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`     | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.Accessibility.isSwitchControlEnabled`          | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` | `AccessibilityProvider`        |                                                                                        |
+| `TelemetryDeck.UserPreference.layoutDirection`                | `AccessibilityProvider`        | Possible values are "rightToLeft" or "leftToRight"                                     |
 
 See [Custom Telemetry](#custom-telemetry) on how to implement your own parameter enrichment.
 
@@ -153,14 +163,13 @@ See [Custom Telemetry](#custom-telemetry) on how to implement your own parameter
 Another way to send signals is to register a custom `TelemetryDeckProvider`.
 A provider uses the TelemetryDeck client in order to queue or send signals based on environment or other triggers.
 
-
 To create a provider, implement the `TelemetryDeckProvider` interface:
 
 ```kotlin
 class CustomProvider: TelemetryDeckProvider {
     override fun register(ctx: Application?, client: TelemetryDeckClient) {
         // configure and start the provider
-        // you may retain a WeakReference to client 
+        // you may retain a WeakReference to client
     }
 
     override fun stop() {
@@ -241,17 +250,14 @@ val builder = TelemetryDeck.Builder()
            .logger(CustomLogger())
 ```
 
-Please note that the logger implementation should be thread safe as it may be invoked in different queues and contexts. 
-
-
+Please note that the logger implementation should be thread safe as it may be invoked in different queues and contexts.
 
 ## Requirements
 
 - Android API 21 or later
 - Kotlin 2.0.20
-- Gradle 6.8.3–8.8*
+- Gradle 6.8.3–8.8\*
 - AGP 7.1.3–8.5
-
 
 ## Migrating providers to 3.0+
 
@@ -262,57 +268,52 @@ To upgrade, please perform the following changes depending on how you use Teleme
 
 ### If you're using the application manifest
 
-* Adapt the manifest of your app and rename all keys from `com.telemetrydeck.sdk.*` to `com.telemetrydeck.*` for example:
+- Adapt the manifest of your app and rename all keys from `com.telemetrydeck.sdk.*` to `com.telemetrydeck.*` for example:
 
 Before:
+
 ```xml
 <meta-data android:name="com.telemetrydeck.sdk.appID" android:value="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" />
 ```
 
 After:
+
 ```xml
 <meta-data android:name="com.telemetrydeck.appID" android:value="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" />
 ```
 
-* In your app sourcecode, rename all uses of `TelemetryManager` to `TelemetryDeck`.
-* If you were using `send()` to send signals, no further changes are needed!
-* If you were using `queue()` to send signals, you will need to rename the method to `TelemetryDeck.signal()`.
+- In your app sourcecode, rename all uses of `TelemetryManager` to `TelemetryDeck`.
+- If you were using `send()` to send signals, no further changes are needed!
+- If you were using `queue()` to send signals, you will need to rename the method to `TelemetryDeck.signal()`.
 
 ### Programmatic Usage
 
-* In your app sourcecode, rename all uses of `TelemetryManager` to `TelemetryDeck`.
-* If you were using `send()` to send signals, no further changes are needed!
-* If you were using `queue()` to send signals, you will need to rename the method to `TelemetryDeck.signal()`.
-* If you had a custom provider configuration, please replace the corresponding providers as follows:
+- In your app sourcecode, rename all uses of `TelemetryManager` to `TelemetryDeck`.
+- If you were using `send()` to send signals, no further changes are needed!
+- If you were using `queue()` to send signals, you will need to rename the method to `TelemetryDeck.signal()`.
+- If you had a custom provider configuration, please replace the corresponding providers as follows:
 
 | Provider (old name)             | Provider (new, 3.0+)                                      |
-|---------------------------------|-----------------------------------------------------------|
+| ------------------------------- | --------------------------------------------------------- |
 | `AppLifecycleTelemetryProvider` | `SessionAppProvider`, `SessionActivityProvider`           |
 | `SessionProvider`               | `SessionAppProvider`                                      |
 | `EnvironmentMetadataProvider`   | `EnvironmentParameterProvider`, `PlatformContextProvider` |
 
-
-
 > [!TIP]
 > You can rename all deprecated classes in your project using the Code Cleanup function in IntelliJ/Android Studio.
 
-
 > [!WARNING]
-> Do not mix usage of `TelemetryManager` and `TelemetryDeck`. Once you're ready to migrate, adapt all uses at the same time.  
-
+> Do not mix usage of `TelemetryManager` and `TelemetryDeck`. Once you're ready to migrate, adapt all uses at the same time.
 
 ### Custom Telemetry
-
 
 Your custom providers must replace `TelemetryProvider` with `TelemetryDeckProvider`.
 
 To adopt the new interface:
 
-* Adapt the signature of the `register` method to `register(ctx: Application?, client: TelemetryDeckSignalProcessor)`
+- Adapt the signature of the `register` method to `register(ctx: Application?, client: TelemetryDeckSignalProcessor)`
 
-The `TelemetryDeckSignalProcessor` interface offers a subset of the `TelemetryDeck` client API which gives you access to: 
+The `TelemetryDeckSignalProcessor` interface offers a subset of the `TelemetryDeck` client API which gives you access to:
 
-* To access the logger, use can use `client.debugLogger`
-* To access the signal cache, use `client.signalCache`
-
-
+- To access the logger, use can use `client.debugLogger`
+- To access the signal cache, use `client.signalCache`

--- a/README.md
+++ b/README.md
@@ -129,45 +129,45 @@ TelemetryDeck.start(application, builder)
 
 By default, Kotlin SDK for TelemetryDeck will include the following environment parameters for each outgoing signal
 
-| Parameter name                                                | Provider                       | Description                                                                            |
-| ------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------- |
-| `TelemetryDeck.Session.started`                               | `SessionAppProvider`           |                                                                                        |
-| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.architecture`                           | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.modelName`                              | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.operatingSystem`                        | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.platform`                               | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.systemMajorMinorVersion`                | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.systemMajorVersion`                     | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.systemVersion`                          | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.orientation`                            | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.Device.screenDensity`                          | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.Device.screenResolutionHeight`                 | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.Device.screenResolutionWidth`                  | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.Device.brand`                                  | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.Device.timeZone`                               | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.SDK.name`                                      | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.SDK.version`                                   | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.SDK.nameAndVersion`                            | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.SDK.buildType`                                 | `EnvironmentParameterProvider` |                                                                                        |
-| `TelemetryDeck.RunContext.locale`                             | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.RunContext.targetEnvironment`                  | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.RunContext.isSideLoaded`                       | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.RunContext.sourceMarketplace`                  | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.Accessibility.isBoldTextEnabled`               | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.fontWeightAdjustment`            | `AccessibilityProvider`        | the amount of font weight adjustment or the value equals 0 if no adjustment is applied |
-| `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`     | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.fontScale`                       | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.isInvertColorsEnabled`           | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.isReduceMotionEnabled`           | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`     | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` | `AccessibilityProvider`        |                                                                                        |
-| `TelemetryDeck.UserPreference.layoutDirection`                | `AccessibilityProvider`        | Possible values are "rightToLeft" or "leftToRight"                                     |
+| Parameter name                                                | Provider                       | Description                                        |
+|---------------------------------------------------------------|--------------------------------|----------------------------------------------------|
+| `TelemetryDeck.Session.started`                               | `SessionAppProvider`           |                                                    |
+| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.architecture`                           | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.modelName`                              | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.operatingSystem`                        | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.platform`                               | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.systemMajorMinorVersion`                | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.systemMajorVersion`                     | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.systemVersion`                          | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.orientation`                            | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.Device.screenDensity`                          | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.Device.screenResolutionHeight`                 | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.Device.screenResolutionWidth`                  | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.Device.brand`                                  | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.Device.timeZone`                               | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.SDK.name`                                      | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.SDK.version`                                   | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.SDK.nameAndVersion`                            | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.SDK.buildType`                                 | `EnvironmentParameterProvider` |                                                    |
+| `TelemetryDeck.RunContext.locale`                             | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.RunContext.targetEnvironment`                  | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.RunContext.isSideLoaded`                       | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.RunContext.sourceMarketplace`                  | `PlatformContextProvider`      |                                                    |
+| `TelemetryDeck.Accessibility.isBoldTextEnabled`               | `AccessibilityProvider`        | API 31 and above                                   |
+| `TelemetryDeck.Accessibility.fontWeightAdjustment`            | `AccessibilityProvider`        | API 31 and above                                   |
+| `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`     | `AccessibilityProvider`        |                                                    |
+| `TelemetryDeck.Accessibility.fontScale`                       | `AccessibilityProvider`        | Mapped to iOS size categories                      |
+| `TelemetryDeck.Accessibility.isInvertColorsEnabled`           | `AccessibilityProvider`        |                                                    |
+| `TelemetryDeck.Accessibility.isReduceMotionEnabled`           | `AccessibilityProvider`        |                                                    |
+| `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`     | `AccessibilityProvider`        |                                                    |
+| `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` | `AccessibilityProvider`        |                                                    |
+| `TelemetryDeck.UserPreference.layoutDirection`                | `AccessibilityProvider`        | Possible values are "rightToLeft" or "leftToRight" |
 
 #### Notes 
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ By default, Kotlin SDK for TelemetryDeck will include the following environment 
 | `TelemetryDeck.RunContext.targetEnvironment`                  | `PlatformContextProvider`      |                                                                                        |
 | `TelemetryDeck.RunContext.isSideLoaded`                       | `PlatformContextProvider`      |                                                                                        |
 | `TelemetryDeck.RunContext.sourceMarketplace`                  | `PlatformContextProvider`      |                                                                                        |
-| `TelemetryDeck.Device.isAccessibilityButtonSupported`         | `AccessibilityProvider`        | if the accessibility button within the system navigation area is supported             |
 | `TelemetryDeck.Accessibility.isBoldTextEnabled`               | `AccessibilityProvider`        |                                                                                        |
 | `TelemetryDeck.Accessibility.fontWeightAdjustment`            | `AccessibilityProvider`        | the amount of font weight adjustment or the value equals 0 if no adjustment is applied |
 | `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`     | `AccessibilityProvider`        |                                                                                        |
@@ -169,6 +168,26 @@ By default, Kotlin SDK for TelemetryDeck will include the following environment 
 | `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`     | `AccessibilityProvider`        |                                                                                        |
 | `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` | `AccessibilityProvider`        |                                                                                        |
 | `TelemetryDeck.UserPreference.layoutDirection`                | `AccessibilityProvider`        | Possible values are "rightToLeft" or "leftToRight"                                     |
+
+#### Notes 
+
+- `TelemetryDeck.Accessibility.fontScale` - the value is mapped to better align with size categories sent by other SDKs:
+
+```
+fontScale <= 0.8f ->                      XS
+fontScale > 0.8f && fontScale < 0.9f ->   S
+fontScale >= 0.9f && fontScale < 1.0f ->  M
+fontScale == 1.0f ->                      L
+fontScale >= 1.0f && fontScale < 1.3f ->  XL
+fontScale >= 1.3f && fontScale < 1.4f ->  XXL
+fontScale >= 1.4f && fontScale < 1.5f ->  XXXL
+fontScale >= 1.5f && fontScale < 1.6f ->  AccessibilityM
+fontScale >= 1.6f && fontScale < 1.7f ->  AccessibilityL
+fontScale >= 1.7f && fontScale < 1.8f ->  AccessibilityXL
+fontScale >= 1.8f && fontScale < 1.9f ->  AccessibilityXXL
+fontScale >= 1.9f && fontScale < 2.0f ->  AccessibilityXXXL
+fontScale >= 2.0f ->                      AccessibilityXXXL
+```
 
 See [Custom Telemetry](#custom-telemetry) on how to implement your own parameter enrichment.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ composeBom = "2024.04.01"
 ktor = "3.0.2"
 kotlinx = "1.7.3"
 coroutines = "1.10.1"
+uiautomator = "2.3.0"
 vanniktech-publish = "0.30.0"
 appcompat = "1.7.0"
 mockk = "1.13.13"
@@ -19,6 +20,7 @@ androidxTest = "1.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     androidTestImplementation(libs.androidx.jUnitTestRules)
     androidTestImplementation(libs.androidx.ui.tooling)
     androidTestImplementation(libs.androidx.ui.test.manifest)
+    androidTestImplementation(libs.androidx.uiautomator)
 
     testImplementation(libs.mockk)
     testImplementation(libs.mockk.android)

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderFontScaleNormalTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderFontScaleNormalTest.kt
@@ -1,0 +1,35 @@
+package com.telemetrydeck.sdk
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.telemetrydeck.sdk.providers.AccessibilityProvider
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AccessibilityProviderFontScaleNormalTest() {
+    private fun createSut(): AccessibilityProvider {
+        val appContext = ApplicationProvider.getApplicationContext<Application>()
+        val sut = AccessibilityProvider()
+        sut.register(appContext,
+            TelemetryDeck(
+                configuration = TelemetryManagerConfiguration("32CB6574-6732-4238-879F-582FEBEB6536"),
+                providers = emptyList()
+            )
+        )
+        return sut
+    }
+
+    @get:Rule
+    val accessibilitySettingsRule = FontScaleTestRule(1.0f)
+
+    @Test
+    fun fontScaleMappingTest() {
+        val sut = createSut()
+        val result = sut.enrich("", null)
+        Assert.assertEquals("L", result["TelemetryDeck.Accessibility.fontScale"])
+    }
+}

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderTest.kt
@@ -1,0 +1,39 @@
+package com.telemetrydeck.sdk
+
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.telemetrydeck.sdk.providers.AccessibilityProvider
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AccessibilityProviderTest {
+    private fun createSut(): AccessibilityProvider {
+        val appContext = ApplicationProvider.getApplicationContext<Application>()
+        val sut = AccessibilityProvider()
+        sut.register(appContext, TelemetryDeck(configuration = TelemetryManagerConfiguration("32CB6574-6732-4238-879F-582FEBEB6536"), providers = emptyList()))
+        return sut
+    }
+
+    @Test
+    fun appendsAllExpectedParameters() {
+        val sut = createSut()
+        val result = sut.enrich("", null)
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.fontWeightAdjustment"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isBoldTextEnabled"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.fontScale"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isInvertColorsEnabled"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isReduceMotionEnabled"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isReduceTransparencyEnabled"))
+        assertTrue(result.containsKey("TelemetryDeck.UserPreference.layoutDirection"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isVoiceOverEnabled"))
+        assertTrue(result.containsKey("TelemetryDeck.Device.isAccessibilityButtonSupported"))
+        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isAudioDescriptionRequested"))
+    }
+
+}

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class AccessibilityProviderTest {
+class AccessibilityProviderEnrichmentParametersTest {
     private fun createSut(): AccessibilityProvider {
         val appContext = ApplicationProvider.getApplicationContext<Application>()
         val sut = AccessibilityProvider()
@@ -32,5 +32,4 @@ class AccessibilityProviderTest {
         assertTrue(result.containsKey("TelemetryDeck.Accessibility.isReduceTransparencyEnabled"))
         assertTrue(result.containsKey("TelemetryDeck.UserPreference.layoutDirection"))
     }
-
 }

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderTest.kt
@@ -31,9 +31,6 @@ class AccessibilityProviderTest {
         assertTrue(result.containsKey("TelemetryDeck.Accessibility.isReduceMotionEnabled"))
         assertTrue(result.containsKey("TelemetryDeck.Accessibility.isReduceTransparencyEnabled"))
         assertTrue(result.containsKey("TelemetryDeck.UserPreference.layoutDirection"))
-        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isVoiceOverEnabled"))
-        assertTrue(result.containsKey("TelemetryDeck.Device.isAccessibilityButtonSupported"))
-        assertTrue(result.containsKey("TelemetryDeck.Accessibility.isAudioDescriptionRequested"))
     }
 
 }

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/FontScaleTestRule.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/FontScaleTestRule.kt
@@ -1,0 +1,67 @@
+package com.telemetrydeck.sdk
+
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class FontScaleTestRule (private val fontScale: Float) : TestRule {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val uiDevice: UiDevice =
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                try {
+                    setupAccessibilityOptions()
+                    base.evaluate()
+                } finally {
+                    cleanupAccessibilityOptions()
+                }
+            }
+        }
+    }
+
+    private fun setupAccessibilityOptions() {
+        enableLargeText()
+    }
+
+    private fun cleanupAccessibilityOptions() {
+       disableLargeText()
+    }
+
+    private fun enableLargeText() {
+        executeShellCommand("settings put system font_scale $fontScale")
+        waitForFontScaleChange(fontScale)
+    }
+
+    private fun disableLargeText() {
+        executeShellCommand("settings put system font_scale 1.0")
+        waitForFontScaleChange(1.0f)
+    }
+
+    private fun waitForFontScaleChange(expectedScale: Float, timeoutMillis: Long = 2000) {
+        val startTime = System.currentTimeMillis()
+        while (System.currentTimeMillis() - startTime < timeoutMillis) {
+            val currentScale = Settings.System.getFloat(
+                context.contentResolver,
+                Settings.System.FONT_SCALE,
+                1.0f
+            )
+            if (currentScale == expectedScale) {
+                return
+            }
+            Thread.sleep(100) // Wait for 100 milliseconds before checking again
+        }
+        throw AssertionError("Font scale did not change to $expectedScale within timeout")
+    }
+
+    private fun executeShellCommand(command: String) {
+        uiDevice.executeShellCommand(command)
+    }
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Accessibility.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Accessibility.kt
@@ -1,0 +1,15 @@
+package com.telemetrydeck.sdk.params
+
+enum class Accessibility(val paramName: String) {
+    FontWeightAdjustment("TelemetryDeck.Accessibility.fontWeightAdjustment"),
+    FontScale("TelemetryDeck.Accessibility.fontScale"),
+    IsBoldTextEnabled("TelemetryDeck.Accessibility.isBoldTextEnabled"),
+    IsDarkerSystemColorsEnabled("TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled"),
+    IsInvertColorsEnabled("TelemetryDeck.Accessibility.isInvertColorsEnabled"),
+    IsReduceMotionEnabled("TelemetryDeck.Accessibility.isReduceMotionEnabled"),
+    IsReduceTransparencyEnabled("TelemetryDeck.Accessibility.isReduceTransparencyEnabled"),
+    IsSwitchControlEnabled("TelemetryDeck.Accessibility.isSwitchControlEnabled"),
+    IsVoiceOverEnabled("TelemetryDeck.Accessibility.isVoiceOverEnabled"),
+    PreferredContentSizeCategory("TelemetryDeck.Accessibility.preferredContentSizeCategory"),
+    ShouldDifferentiateWithoutColor("TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor"),
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Accessibility.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Accessibility.kt
@@ -7,9 +7,9 @@ enum class Accessibility(val paramName: String) {
     IsDarkerSystemColorsEnabled("TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled"),
     IsInvertColorsEnabled("TelemetryDeck.Accessibility.isInvertColorsEnabled"),
     IsReduceMotionEnabled("TelemetryDeck.Accessibility.isReduceMotionEnabled"),
+    IsAudioDescriptionRequested("TelemetryDeck.Accessibility.isAudioDescriptionRequested"),
     IsReduceTransparencyEnabled("TelemetryDeck.Accessibility.isReduceTransparencyEnabled"),
     IsSwitchControlEnabled("TelemetryDeck.Accessibility.isSwitchControlEnabled"),
     IsVoiceOverEnabled("TelemetryDeck.Accessibility.isVoiceOverEnabled"),
-    PreferredContentSizeCategory("TelemetryDeck.Accessibility.preferredContentSizeCategory"),
     ShouldDifferentiateWithoutColor("TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor"),
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Accessibility.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Accessibility.kt
@@ -7,9 +7,6 @@ enum class Accessibility(val paramName: String) {
     IsDarkerSystemColorsEnabled("TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled"),
     IsInvertColorsEnabled("TelemetryDeck.Accessibility.isInvertColorsEnabled"),
     IsReduceMotionEnabled("TelemetryDeck.Accessibility.isReduceMotionEnabled"),
-    IsAudioDescriptionRequested("TelemetryDeck.Accessibility.isAudioDescriptionRequested"),
     IsReduceTransparencyEnabled("TelemetryDeck.Accessibility.isReduceTransparencyEnabled"),
-    IsSwitchControlEnabled("TelemetryDeck.Accessibility.isSwitchControlEnabled"),
-    IsVoiceOverEnabled("TelemetryDeck.Accessibility.isVoiceOverEnabled"),
     ShouldDifferentiateWithoutColor("TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor"),
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Device.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Device.kt
@@ -14,5 +14,6 @@ internal enum class Device(val paramName: String) {
     Orientation("TelemetryDeck.Device.orientation"), // iOS compatibility note: on Android, there are additional orientations
     ScreenDensity("TelemetryDeck.Device.screenDensity"),
     ScreenHeight("TelemetryDeck.Device.screenResolutionHeight"),
-    ScreenWidth("TelemetryDeck.Device.screenResolutionWidth")
+    ScreenWidth("TelemetryDeck.Device.screenResolutionWidth"),
+    IsAccessibilityButtonSupported("TelemetryDeck.Device.isAccessibilityButtonSupported"),
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Device.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Device.kt
@@ -15,5 +15,4 @@ internal enum class Device(val paramName: String) {
     ScreenDensity("TelemetryDeck.Device.screenDensity"),
     ScreenHeight("TelemetryDeck.Device.screenResolutionHeight"),
     ScreenWidth("TelemetryDeck.Device.screenResolutionWidth"),
-    IsAccessibilityButtonSupported("TelemetryDeck.Device.isAccessibilityButtonSupported"),
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/UserPreference.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/UserPreference.kt
@@ -1,0 +1,5 @@
+package com.telemetrydeck.sdk.params
+
+enum class UserPreferences(val paramName: String) {
+    LayoutDirection("TelemetryDeck.UserPreference.layoutDirection"),
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/AccessibilityProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/AccessibilityProvider.kt
@@ -1,0 +1,152 @@
+package com.telemetrydeck.sdk.providers
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.app.Application
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import android.provider.Settings
+import android.view.accessibility.AccessibilityManager
+import com.telemetrydeck.sdk.TelemetryDeckProvider
+import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
+import com.telemetrydeck.sdk.params.Accessibility
+import java.lang.ref.WeakReference
+
+
+class AccessibilityProvider : TelemetryDeckProvider {
+    private var app: WeakReference<Application?>? = null
+    private var manager: WeakReference<TelemetryDeckSignalProcessor>? = null
+
+    override fun register(ctx: Application?, client: TelemetryDeckSignalProcessor) {
+        this.app = WeakReference(ctx)
+        this.manager = WeakReference(client)
+    }
+
+    override fun stop() {
+
+    }
+
+    override fun enrich(
+        signalType: String,
+        clientUser: String?,
+        additionalPayload: Map<String, String>
+    ): Map<String, String> {
+        val signalPayload = additionalPayload.toMutableMap()
+        for (item in getConfigurationParams()) {
+            if (!signalPayload.containsKey(item.key)) {
+                signalPayload[item.key] = item.value
+            }
+        }
+        return signalPayload
+    }
+
+    private fun getConfigurationParams(): Map<String, String> {
+
+        val context = this.app?.get()?.applicationContext ?: return emptyMap()
+        val config = context.resources.configuration
+        val attributes = mutableMapOf<String, String>()
+
+        try {
+
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                attributes[Accessibility.FontWeightAdjustment.paramName] =
+                    "${config.fontWeightAdjustment}"
+                attributes[Accessibility.IsBoldTextEnabled.paramName] =
+                    "${config.fontWeightAdjustment > 0}"
+            }
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+
+
+        try {
+            isDarkModeEnabled().let {
+                attributes[Accessibility.IsDarkerSystemColorsEnabled.paramName] = "$it"
+            }
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+
+        try {
+            attributes[Accessibility.FontScale.paramName] = "${config.fontScale}"
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+
+        try {
+            val isColorInversionEnabled = Settings.Secure.getInt(
+                context.contentResolver,
+                Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED,
+                0 // Default value if the setting is not found
+            ) == 1
+            attributes[Accessibility.IsInvertColorsEnabled.paramName] = "$isColorInversionEnabled"
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+
+        try {
+            val isColorInversionEnabled = Settings.Secure.getInt(
+                context.contentResolver,
+                Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED,
+                0 // Default value if the setting is not found
+            ) == 1
+            attributes[Accessibility.IsInvertColorsEnabled.paramName] = "$isColorInversionEnabled"
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+
+        try {
+            val transitionAnimationScale = Settings.Global.getFloat(
+                context.contentResolver,
+                Settings.Global.TRANSITION_ANIMATION_SCALE
+            )
+
+            val animatorDurationScale = Settings.Global.getFloat(
+                context.contentResolver,
+                Settings.Global.ANIMATOR_DURATION_SCALE
+            )
+
+            attributes[Accessibility.IsReduceMotionEnabled.paramName] = "${transitionAnimationScale == 0.0f && animatorDurationScale == 0.0f}"
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+
+        try {
+            val am = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+            val screenReaders = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_SPOKEN)
+            attributes[Accessibility.IsVoiceOverEnabled.paramName] = "${screenReaders.isNotEmpty()}"
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error(e.stackTraceToString())
+        }
+
+        return attributes
+
+    }
+
+    private fun isDarkModeEnabled(): Boolean? {
+        val context = this.app?.get()?.applicationContext ?: return null
+        val nightModeFlags: Int =
+            context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+
+        when (nightModeFlags) {
+            Configuration.UI_MODE_NIGHT_YES -> {
+                return true
+            }
+
+            Configuration.UI_MODE_NIGHT_NO -> {
+                return false
+            }
+
+            Configuration.UI_MODE_NIGHT_UNDEFINED -> {
+                return null
+            }
+        }
+
+        return null
+    }
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/AccessibilityProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/AccessibilityProvider.kt
@@ -1,18 +1,14 @@
 package com.telemetrydeck.sdk.providers
 
-import android.accessibilityservice.AccessibilityServiceInfo
 import android.app.Application
-import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
 import android.provider.Settings
 import android.util.LayoutDirection
-import android.view.accessibility.AccessibilityManager
 import androidx.core.text.layoutDirection
 import com.telemetrydeck.sdk.TelemetryDeckProvider
 import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
 import com.telemetrydeck.sdk.params.Accessibility
-import com.telemetrydeck.sdk.params.Device
 import com.telemetrydeck.sdk.params.UserPreferences
 import java.lang.ref.WeakReference
 import java.util.Locale
@@ -72,7 +68,7 @@ class AccessibilityProvider : TelemetryDeckProvider {
         }
 
         try {
-            attributes[Accessibility.FontScale.paramName] = "${config.fontScale}"
+            attributes[Accessibility.FontScale.paramName] = mapFontScaleToTelemetryValue(config.fontScale).scale
         } catch (e: Exception) {
             this.manager?.get()?.debugLogger?.error("Error detecting FontScale: ${e.stackTraceToString()}")
         }
@@ -155,6 +151,43 @@ class AccessibilityProvider : TelemetryDeckProvider {
         }
 
         return null
+    }
+
+
+    fun mapFontScaleToTelemetryValue(fontScale: Float): TelemetryValue {
+        // Note: font scale of 1.0 maps to TelemetryValue.L to match the scale in the SwiftSDK
+        when {
+            fontScale <= 0.8f -> return TelemetryValue.XS
+            fontScale > 0.8f && fontScale < 0.9f -> return TelemetryValue.S
+            fontScale >= 0.9f && fontScale < 1.0f -> return TelemetryValue.M
+            fontScale == 1.0f -> return TelemetryValue.L
+            fontScale >= 1.0f && fontScale < 1.3f -> return TelemetryValue.XL
+            fontScale >= 1.3f && fontScale < 1.4f -> return TelemetryValue.XXL
+            fontScale >= 1.4f && fontScale < 1.5f -> return TelemetryValue.XXXL
+            fontScale >= 1.5f && fontScale < 1.6f -> return TelemetryValue.AccessibilityM
+            fontScale >= 1.6f && fontScale < 1.7f -> return TelemetryValue.AccessibilityL
+            fontScale >= 1.7f && fontScale < 1.8f -> return TelemetryValue.AccessibilityXL
+            fontScale >= 1.8f && fontScale < 1.9f -> return TelemetryValue.AccessibilityXXL
+            fontScale >= 1.9f && fontScale < 2.0f -> return TelemetryValue.AccessibilityXXXL
+            fontScale >= 2.0f -> return TelemetryValue.AccessibilityXXXL
+            else -> return TelemetryValue.Unspecified
+        }
+    }
+
+    enum class TelemetryValue(val scale: String) {
+        Unspecified("unspecified"),
+        XS("XS"),
+        S("S"),
+        M("M"),
+        L("L"),
+        XL("XL"),
+        XXL("XXL"),
+        XXXL("XXXL"),
+        AccessibilityM("AccessibilityM"),
+        AccessibilityL("AccessibilityL"),
+        AccessibilityXL("AccessibilityXL"),
+        AccessibilityXXL("AccessibilityXXL"),
+        AccessibilityXXXL("AccessibilityXXXL"),
     }
 }
 


### PR DESCRIPTION
Fixes #42 

- [x] `TelemetryDeck.Accessibility.isBoldTextEnabled` -  is available on API 31 and above
- [x] `TelemetryDeck.Accessibility.fontWeightAdjustment` -  is Android only, the value equals 0 if no adjustment is applied
- [x] `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`
- [x] `TelemetryDeck.Accessibility.fontScale` - is Android only
- [x] `TelemetryDeck.Accessibility.isInvertColorsEnabled`
- [x] `TelemetryDeck.Accessibility.isVoiceOverEnabled` - I kept the name for consistency, but clearly on Android the default service is called TalkBack, alternatives are also possible. The flag returns true if any voice feedback service is enabled.
- [x] `TelemetryDeck.Accessibility.isReduceMotionEnabled`
- [x] `TelemetryDeck.Device.isAccessibilityButtonSupported` - Android only, true if the accessibility button within the system navigation area is supported. 
- [x] `TelemetryDeck.Accessibility.isAudioDescriptionRequested` - Android only, true if users want to select soundtrack with audio description by default
- [x] `TelemetryDeck.UserPreference.colorScheme` - **N/A** as devices support various themes and styles. With this PR, `isDarkerSystemColorsEnabled` returns `true` if the current theme has dark-mode like features, but the opposite is not necessarily true.

- [x] `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`
- [x] `TelemetryDeck.Accessibility.isSwitchControlEnabled`
- [x] `TelemetryDeck.Accessibility.preferredContentSizeCategory` - **N/A** as devices support different font styles. `TelemetryDeck.Accessibility.fontScale` and `TelemetryDeck.Accessibility.fontWeightAdjustment` have been added to reflect the exact font metrics.
- [x] `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` - based on `accessibility_display_daltonizer_enabled`
- [x] `TelemetryDeck.UserPreference.layoutDirection`


The [README](https://github.com/TelemetryDeck/KotlinSDK/blob/06fee784485e5f10b9b54cb93727c871a8081871/README.md#environment-parameters) has been updated to include the list above.

@Jeehut @winsmith Please feel free to have a look. Thoughts and comments are always welcome.
