### PR TITLE
Add signal duration tacking

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ vanniktech-publish = "0.30.0"
 appcompat = "1.7.0"
 mockk = "1.13.13"
 robolectric = "4.7.3"
+androidxTest = "1.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -43,6 +44,7 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 mockk = {group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-agent = {group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
 mockk-android = {group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
+androidx-jUnitTestRules = { module = "androidx.test:rules", version.ref = "androidxTest" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(libs.androidx.jUnitTestRules)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/DurationSignalTrackerProviderTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/DurationSignalTrackerProviderTest.kt
@@ -18,6 +18,8 @@ import java.util.Date
 @RunWith(AndroidJUnit4::class)
 class DurationSignalTrackerProviderTest {
 
+    // One or more digits, a dot, then exactly three digits
+    val regex = Regex("^\\d+\\.\\d{3}$")
 
     private fun createSut(): DurationSignalTrackerProvider {
         val appContext = ApplicationProvider.getApplicationContext<Application>()
@@ -42,10 +44,16 @@ class DurationSignalTrackerProviderTest {
         Thread.sleep(5000)
         val params = sut.stopTracking("signal1", emptyMap())
 
+
+        val value = params?.get(Signal.DurationInSeconds.signalName)
+
+        // ensure precision of 3
+        assert(value != null)
+        assert(value!!.matches(regex))
+
         // assert a duration is present and bigger or euqal to 5
-        val duration = params?.get(Signal.DurationInSeconds.signalName)?.toDouble()
-        assert(duration != null)
-        assert(duration!! >= 5.0)
+        val duration = value.toDouble()
+        assert(duration >= 5.0)
     }
 
     @UiThreadTest
@@ -59,10 +67,16 @@ class DurationSignalTrackerProviderTest {
 
         assertEquals("value1", params?.get("param1"))
         assertEquals("value3", params?.get("param2"))
+
+        val value = params?.get(Signal.DurationInSeconds.signalName)
+
+        // ensure precision of 3
+        assert(value != null)
+        assert(value!!.matches(regex))
+
         // assert a duration is present and bigger or euqal to 5
-        val duration = params?.get(Signal.DurationInSeconds.signalName)?.toDouble()
-        assert(duration != null)
-        assert(duration!! >= 5.0)
+        val duration = value.toDouble()
+        assert(duration >= 5.0)
     }
 
     @UiThreadTest
@@ -82,10 +96,15 @@ class DurationSignalTrackerProviderTest {
 
         assertEquals("value1", params?.get("param1"))
         assertEquals("value3", params?.get("param2"))
-        val duration = params?.get(Signal.DurationInSeconds.signalName)?.toDouble()
-        assert(duration != null)
-        println(duration)
-        assert(duration!! > 7200)
+
+        val value = params?.get(Signal.DurationInSeconds.signalName)
+
+        // ensure precision of 3
+        assert(value != null)
+        assert(value!!.matches(regex))
+
+        val duration = value.toDouble()
+        assert(duration > 7200)
     }
 
     @UiThreadTest
@@ -106,9 +125,14 @@ class DurationSignalTrackerProviderTest {
 
         assertEquals("value1", params?.get("param1"))
         assertEquals("value3", params?.get("param2"))
-        val duration = params?.get(Signal.DurationInSeconds.signalName)?.toDouble()
-        assert(duration != null)
-        println(duration)
-        assert(duration!! < 3600)
+
+        val value = params?.get(Signal.DurationInSeconds.signalName)
+
+        // ensure precision of 3
+        assert(value != null)
+        assert(value!!.matches(regex))
+
+        val duration = value.toDouble()
+        assert(duration < 3600)
     }
 }

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/DurationSignalTrackerProviderTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/DurationSignalTrackerProviderTest.kt
@@ -1,0 +1,114 @@
+package com.telemetrydeck.sdk
+
+import android.app.Application
+import androidx.test.annotation.UiThreadTest
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.telemetrydeck.sdk.providers.DurationSignalTrackerProvider
+import com.telemetrydeck.sdk.signals.Signal
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.Date
+
+
+@RunWith(AndroidJUnit4::class)
+class DurationSignalTrackerProviderTest {
+
+
+    private fun createSut(): DurationSignalTrackerProvider {
+        val appContext = ApplicationProvider.getApplicationContext<Application>()
+        val sut = DurationSignalTrackerProvider()
+        sut.register(appContext, TelemetryDeck(configuration = TelemetryManagerConfiguration("32CB6574-6732-4238-879F-582FEBEB6536"), providers = emptyList()))
+        return sut
+    }
+
+    private fun prepareState(state: DurationSignalTrackerProvider.TrackerState) {
+        val appContext = ApplicationProvider.getApplicationContext<Application>()
+        val file = File(appContext.filesDir, "telemetrydeckduration")
+        val value = Json.encodeToString(state)
+        file.writeText(value)
+    }
+
+    @UiThreadTest
+    @Test
+    fun tracks_a_signal_duration() {
+        val sut = createSut()
+        sut.startTracking("signal1", emptyMap())
+        // sleep for 5 seconds
+        Thread.sleep(5000)
+        val params = sut.stopTracking("signal1", emptyMap())
+
+        // assert a duration is present and bigger or euqal to 5
+        val duration = params?.get(Signal.DurationInSeconds.signalName)?.toDouble()
+        assert(duration != null)
+        assert(duration!! >= 5.0)
+    }
+
+    @UiThreadTest
+    @Test
+    fun tracks_a_signal_duration_with_starting_and_endingparams() {
+        val sut = createSut()
+        sut.startTracking("signal1", mapOf("param1" to "value1"))
+        // sleep for 5 seconds
+        Thread.sleep(5000)
+        val params = sut.stopTracking("signal1", mapOf("param2" to "value3"))
+
+        assertEquals("value1", params?.get("param1"))
+        assertEquals("value3", params?.get("param2"))
+        // assert a duration is present and bigger or euqal to 5
+        val duration = params?.get(Signal.DurationInSeconds.signalName)?.toDouble()
+        assert(duration != null)
+        assert(duration!! >= 5.0)
+    }
+
+    @UiThreadTest
+    @Test
+    fun restores_state_from_disk() {
+        val now = Date()
+        val twoHoursAgo = Date(now.time - 7200000)
+        val hourAgo = Date(now.time - 3600000)
+        val state = DurationSignalTrackerProvider.TrackerState(
+            signals = mapOf("signal1" to DurationSignalTrackerProvider.CachedData(startTime = twoHoursAgo, parameters = mapOf("param1" to "value1"))),
+            lastEnteredBackground = hourAgo
+        )
+        prepareState(state)
+
+        val sut = createSut()
+        val params = sut.stopTracking("signal1", mapOf("param2" to "value3"))
+
+        assertEquals("value1", params?.get("param1"))
+        assertEquals("value3", params?.get("param2"))
+        val duration = params?.get(Signal.DurationInSeconds.signalName)?.toDouble()
+        assert(duration != null)
+        println(duration)
+        assert(duration!! > 7200)
+    }
+
+    @UiThreadTest
+    @Test
+    fun substracts_background_time() {
+        val now = Date()
+        val twoHoursAgo = Date(now.time - 7200000)
+        val hourAgo = Date(now.time - 3700000)
+        val state = DurationSignalTrackerProvider.TrackerState(
+            signals = mapOf("signal1" to DurationSignalTrackerProvider.CachedData(startTime = twoHoursAgo, parameters = mapOf("param1" to "value1"))),
+            lastEnteredBackground = hourAgo
+        )
+        prepareState(state)
+        val sut = createSut()
+
+        sut.handleOnStart()
+        val params = sut.stopTracking("signal1", mapOf("param2" to "value3"))
+
+        assertEquals("value1", params?.get("param1"))
+        assertEquals("value3", params?.get("param2"))
+        val duration = params?.get(Signal.DurationInSeconds.signalName)?.toDouble()
+        assert(duration != null)
+        println(duration)
+        assert(duration!! < 3600)
+    }
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -210,6 +210,7 @@ class TelemetryDeck(
                 EnvironmentParameterProvider(),
                 PlatformContextProvider()
             )
+        internal val alwaysOnProviders = listOf(DurationSignalTrackerProvider())
 
         // TelemetryManager singleton
         @Volatile
@@ -463,6 +464,7 @@ class TelemetryDeck(
             if (providers == null) {
                 providers = defaultTelemetryProviders
             }
+            providers = providers + alwaysOnProviders
             // check for additional providers that should be appended
             if (additionalProviders != null) {
                 providers = providers + (additionalProviders?.toList() ?: listOf())

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -95,5 +95,35 @@ interface TelemetryDeckClient {
         params: Map<String, String> = emptyMap(),
     )
 
+    /** Starts tracking the duration of a signal without sending it yet.
+     *
+     * This function only starts tracking time – it does not send a signal. You must call `[stopAndSendDurationSignal]`
+     * with the same signal name to finalize and actually send the signal with the tracked duration.
+     *
+     * Calling this method twice for the same signal name will replace the previous tracking.
+     *
+     * @param signalName The name of the signal to track. This will be used to identify and stop the duration tracking later.
+     * @param parameters A dictionary of additional string key-value pairs that will be included when the duration signal is eventually sent.
+     */
+    fun startDurationSignal(signalName: String, parameters: Map<String, String> = emptyMap())
+
+    /** Stops tracking the duration of a signal and sends it with the total duration.
+     *
+     * This function finalizes the duration tracking by:
+     * 1. Stopping the timer for the given signal name
+     * 2. Calculating the duration in seconds (excluding background time)
+     * 3. Sending a signal that includes the start parameters, stop parameters, and calculated duration
+     *
+     * Tracked time will be included as a value of `TelemetryDeck.Signal.durationInSeconds`.
+     * Tracked time only includes time while the app is in the foreground.
+     *
+     * Note: If no matching signal was started, this function has no effect.
+     *
+     * @param signalName The name of the signal that was previously started with [startDurationSignal]
+     * @param parameters Additional parameters to include with the signal. These will be merged with the parameters provided at the start.
+     *
+     */
+    fun stopAndSendDurationSignal(signalName: String, parameters: Map<String, String> = emptyMap())
+
     val configuration: TelemetryManagerConfiguration?
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/DurationSignalTrackerProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/DurationSignalTrackerProvider.kt
@@ -113,7 +113,7 @@ class DurationSignalTrackerProvider : TelemetryDeckProvider, DefaultLifecycleObs
         for (param in parameters) {
             mergedParameters[param.key] = param.value
         }
-        mergedParameters[Signal.DurationInSeconds.signalName] = trackingDurationSec.toString()
+        mergedParameters[Signal.DurationInSeconds.signalName] = "%.3f".format(trackingDurationSec)
 
        return mergedParameters
     }

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/DurationSignalTrackerProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/DurationSignalTrackerProvider.kt
@@ -1,0 +1,163 @@
+package com.telemetrydeck.sdk.providers
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.telemetrydeck.sdk.DateSerializer
+import com.telemetrydeck.sdk.TelemetryDeckProvider
+import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
+import com.telemetrydeck.sdk.signals.Signal
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.lang.ref.WeakReference
+import java.util.Date
+
+class DurationSignalTrackerProvider : TelemetryDeckProvider, DefaultLifecycleObserver {
+    private var appContext: WeakReference<Context?>? = null
+    private var manager: WeakReference<TelemetryDeckSignalProcessor>? = null
+    private var state: TrackerState? = null
+    private val fileName = "telemetrydeckduration"
+    private val fileEncoding = Charsets.UTF_8
+
+    override fun register(ctx: Application?, client: TelemetryDeckSignalProcessor) {
+        this.manager = WeakReference(client)
+        this.appContext = WeakReference(ctx?.applicationContext)
+        this.state = restoreStateFromDisk() ?: TrackerState(emptyMap())
+        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+    }
+
+    override fun stop() {
+
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        handleOnStart()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        handleOnStop()
+    }
+
+    fun handleOnStart() {
+        val preRestoreState = this.state
+        if (preRestoreState == null) {
+            // no state present in memory, restore it
+            val restoredState = restoreStateFromDisk()
+            this.state = restoredState
+        }
+
+        var currentState = this.state
+            ?: // nothing to do, probably not started yet
+            return
+
+        val lastEnteredBackground = currentState.lastEnteredBackground
+        if (lastEnteredBackground != null) {
+            // subtracts background time from all signals by moving their start time forward
+            val now = Date()
+            val backgroundDuration = now.time - lastEnteredBackground.time
+            currentState = currentState.copy(
+                signals = currentState.signals.mapValues {
+                    it.value.copy(
+                        startTime = Date(it.value.startTime.time + backgroundDuration)
+                    )
+                }
+            )
+        }
+
+        writeStateToDisk(currentState)
+        this.state = currentState
+    }
+
+    fun handleOnStop() {
+        val currentState = this.state
+        if (currentState != null) {
+            writeStateToDisk(currentState)
+        }
+    }
+
+    @Synchronized
+    fun startTracking(signalName: String, parameters: Map<String, String>) {
+        val currentState = state ?: throw Exception("startTracking called before register")
+        val now = Date()
+        this.state = currentState.copy(
+            signals = currentState.signals + (signalName to CachedData(
+                now,
+                parameters
+            ))
+        )
+    }
+
+    @Synchronized
+    fun stopTracking(signalName: String, parameters: Map<String, String>): Map<String, String>? {
+        val currentState = state ?: throw Exception("stopTracking called before register")
+        val signalTracking = currentState.signals[signalName]
+        if (signalTracking == null) {
+            this.manager?.get()?.debugLogger?.error("stopTracking called for untracked signal $signalName. Did you forget to call startTracking?")
+            return null
+        }
+        // stop tracking the signal name
+        this.state = currentState.copy(signals = currentState.signals - signalName)
+
+        // queue a duration signal for sending
+        val trackingDurationMs = Date().time - signalTracking.startTime.time
+        val trackingDurationSec = trackingDurationMs / 1000.0
+
+        val mergedParameters = mutableMapOf<String, String>()
+        for (param in signalTracking.parameters) {
+            mergedParameters[param.key] = param.value
+        }
+        for (param in parameters) {
+            mergedParameters[param.key] = param.value
+        }
+        mergedParameters[Signal.DurationInSeconds.signalName] = trackingDurationSec.toString()
+
+       return mergedParameters
+    }
+
+    private fun restoreStateFromDisk(): TrackerState? {
+        val context = this.appContext?.get() ?: return null
+        try {
+            val file = File(context.filesDir, fileName)
+            if (file.exists()) {
+                val json = file.readText(fileEncoding)
+                val state = Json.decodeFromString<TrackerState>(json)
+                return state
+            }
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error("failed to restore duration tracking state ${e.stackTraceToString()}")
+        }
+        return null
+    }
+
+    private fun writeStateToDisk(state: TrackerState) {
+        val context = this.appContext?.get() ?: return
+        try {
+            val file = File(context.filesDir, fileName)
+            if (file.exists()) {
+                file.delete()
+            }
+            val json = Json.encodeToString(state)
+            file.writeText(json, fileEncoding)
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error("failed to write duration tracking state ${e.stackTraceToString()}")
+        }
+    }
+
+    @Serializable
+    data class TrackerState(
+        val signals: Map<String, CachedData>,
+        @Serializable(with = DateSerializer::class)
+        val lastEnteredBackground: Date? = null
+    )
+
+    @Serializable
+    data class CachedData(
+        @Serializable(with = DateSerializer::class)
+        val startTime: Date,
+        val parameters: Map<String, String>
+    )
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/signals/Signal.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/signals/Signal.kt
@@ -1,0 +1,5 @@
+package com.telemetrydeck.sdk.signals
+
+enum class Signal(val signalName: String) {
+    DurationInSeconds("TelemetryDeck.Signal.durationInSeconds")
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -243,7 +243,7 @@ class TelemetryDeckTests {
             .build(null)
         sut.signal("type")
 
-        Assert.assertEquals(4, sut.providers.count())
+        Assert.assertEquals(4 + 1, sut.providers.count()) // added providers + default ones we always apeend
         Assert.assertTrue(sut.providers.last() is TestTelemetryDeckProvider)
     }
 

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -433,6 +433,24 @@ class TelemetryDeckTests {
         Assert.assertEquals(hashString("always the same"), queuedSignal?.clientUser)
     }
 
+    @Test
+    fun telemetryDeck_allows_duration_signal_tracking() {
+        val appID = "32CB6574-6732-4238-879F-582FEBEB6536"
+        val config = TelemetryManagerConfiguration(appID)
+        val manager = TelemetryDeck.Builder().configuration(config).build(null)
+
+        manager.startDurationSignal("type")
+        manager.stopAndSendDurationSignal("type")
+
+        val queuedSignal = manager.cache?.empty()?.first()
+
+        Assert.assertNotNull(queuedSignal)
+        Assert.assertEquals(UUID.fromString(appID), queuedSignal!!.appID)
+        Assert.assertEquals(config.sessionID, UUID.fromString(queuedSignal.sessionID))
+        val duration = queuedSignal.payload.find {  it.startsWith("TelemetryDeck.Signal.durationInSeconds:") }
+        Assert.assertNotNull(duration)
+    }
+
     private fun hashString(input: String, algorithm: String = "SHA-256"): String {
         return MessageDigest.getInstance(algorithm)
             .digest(input.toByteArray())


### PR DESCRIPTION
This PR fixes #51 by adding signal duration tracking. The public API is compatible with the iOS implementation (https://github.com/TelemetryDeck/SwiftSDK/pull/224):

```kotlin
TelemetryDeck.startDurationSignal("signal")
TelemetryDeck.stopAndSendDurationSignal("signal")
```

Notes:

- Duration tracking state is persisted if the app gets terminated in the background and restored on resume.
- Session duration is always provided with a precision of 3 e.g. `23.040` 