### PR TITLE
Remove dependency on Compose plugin, remove ui tooling from debug builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,5 @@ plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.serialization) apply false
-    alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.vanniktech.publish) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-agp = "8.7.3"
+agp = "8.8.0"
 kotlin = "2.0.20"
-coreKtx = "1.13.1"
+coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.3"
-composeBom = "2024.10.00"
+activityCompose = "1.10.0"
+composeBom = "2024.04.01"
 ktor = "3.0.2"
 kotlinx = "1.7.3"
-coroutines = "1.9.0"
+coroutines = "1.10.1"
 vanniktech-publish = "0.30.0"
 appcompat = "1.7.0"
 mockk = "1.13.13"
@@ -49,4 +49,3 @@ androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 vanniktech-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-publish" }
-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.vanniktech.publish)
 }
 
@@ -44,7 +43,7 @@ android {
         jvmTarget = "11"
     }
     buildFeatures {
-        compose = true
+        compose = false
         buildConfig = true
     }
 
@@ -68,10 +67,6 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.process)
-    // explicit dependency on compose seems to be required to use the compose compiler
-    // this is not used by the library atm
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.appcompat)
     implementation(libs.ktor.client.core)
     implementation(libs.kotlinx.coroutines.core)
@@ -86,13 +81,15 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.androidx.arch.core)
-
+    // As of Kotlin 2.0, the Compose Compiler and runtime are required in the classpath https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html
+    testImplementation(libs.androidx.activity.compose)
+    testImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
+    androidTestImplementation(libs.androidx.ui.tooling)
+    androidTestImplementation(libs.androidx.ui.test.manifest)
 
     testImplementation(libs.mockk)
     testImplementation(libs.mockk.android)


### PR DESCRIPTION
Hi @winsmith,

This PR fixes #61 by removing the direct dependency on the compose compiler plugin. It also corrects a bug introduced in v3 where the UI tooling we use during unit tests were incorrectly included as a dependency for debug builds (my bad). 

To note, the compose compiler is [part of Kotlin 2.0 and later](https://kotlinlang.org/docs/compose-compiler-migration-guide.html) - the compose runtime may still be required in the class path of consuming apps depending on their setup. This [AGP compatibility table](https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin) applies.

I also explored the option to downgrade to Kotlin 1.9, however the latest versions of some of our dependencies no longer support Kotlin 1.9, and so I wouldn't recommend it.