### PR TITLE
Add a way to include default parameters with all signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,24 @@ By default, Kotlin SDK for TelemetryDeck will include the following environment 
 
 See [Custom Telemetry](#custom-telemetry) on how to implement your own parameter enrichment.
 
+## Default Parameters
+
+If there are parameters you would like to include with every outgoing signal, you can use `DefaultParameterProvider` instead of passing them with every call.
+
+```kotlin
+// create an instance of [DefaultParameterProvider] and pass the key value you wish to be appended to every signal
+val provider = DefaultParameterProvider(mapOf("key" to "value"))
+
+// add the provider when configuring an instance of TelemetryDeck
+
+val builder = TelemetryDeck.Builder()
+    .appID("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
+    .addProvider(provider)
+```
+
 ## Custom Telemetry
 
-Another way to send signals is to register a custom `TelemetryDeckProvider`.
+Another way to send signals is to implement a custom `TelemetryDeckProvider`.
 A provider uses the TelemetryDeck client in order to queue or send signals based on environment or other triggers.
 
 

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/DefaultParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/DefaultParameterProvider.kt
@@ -1,0 +1,38 @@
+package com.telemetrydeck.sdk.providers
+
+import android.app.Application
+import com.telemetrydeck.sdk.TelemetryDeckProvider
+import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
+
+
+/**
+ * [DefaultParameterProvider] is a [TelemetryDeckProvider] that adds default parameters
+ * to every telemetry signal. It ensures that signals are enriched with predefined data,
+ * unless the signal already contains a value for the same key.
+ *
+ * @property defaultParameters A map of key-value pairs representing the default parameters
+ *                            that will be added to each telemetry signal.
+ */
+class DefaultParameterProvider(val defaultParameters: Map<String, String>): TelemetryDeckProvider {
+    override fun register(ctx: Application?, client: TelemetryDeckSignalProcessor) {
+        // nothing to do
+    }
+
+    override fun stop() {
+        // nothing to do
+    }
+
+    override fun enrich(
+        signalType: String,
+        clientUser: String?,
+        additionalPayload: Map<String, String>
+    ): Map<String, String> {
+        val signalPayload = additionalPayload.toMutableMap()
+        for (item in defaultParameters) {
+            if (!signalPayload.containsKey(item.key)) {
+                signalPayload[item.key] = item.value
+            }
+        }
+        return signalPayload
+    }
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -2,6 +2,7 @@ package com.telemetrydeck.sdk
 
 import android.app.Application
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.telemetrydeck.sdk.providers.DefaultParameterProvider
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -431,6 +432,23 @@ class TelemetryDeckTests {
 
         val queuedSignal = telemetryDeck.cache?.empty()?.first()
         Assert.assertEquals(hashString("always the same"), queuedSignal?.clientUser)
+    }
+
+    @Test
+    fun telemetryDeck_supports_default_parameter_provider() {
+        val config = TelemetryManagerConfiguration("32CB6574-6732-4238-879F-582FEBEB6536")
+        val manager = TelemetryDeck.Builder().addProvider(DefaultParameterProvider(mapOf("param1" to "value1"))).configuration(config).build(null)
+
+        manager.signal("test")
+
+        val queuedSignal = manager.cache?.empty()?.first()
+
+        Assert.assertNotNull(queuedSignal)
+
+        // validate the signal type
+        Assert.assertEquals(queuedSignal?.type, "test")
+
+        Assert.assertEquals("param1:value1", queuedSignal?.payload?.firstOrNull { it.startsWith("param1:") }, )
     }
 
     private fun hashString(input: String, algorithm: String = "SHA-256"): String {


### PR DESCRIPTION
This PR fixes #45 by making it possible to specify a map of default parameter values to be appended with outgoing signals. The feature is opt-in and can be enabled by adding our default parameter provider:

```kotlin
// create an instance of [DefaultParameterProvider] and pass the key value you wish to be appended to every signal
val provider = DefaultParameterProvider(mapOf("key" to "value"))

// add the provider when configuring an instance of TelemetryDeck

val builder = TelemetryDeck.Builder()
    .appID("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
    .addProvider(provider)
```