### PR TITLE
Add a way to set default prefix for signals and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ By default, Kotlin SDK for TelemetryDeck will include the following environment 
 
 See [Custom Telemetry](#custom-telemetry) on how to implement your own parameter enrichment.
 
+## Default prefix
+
+If you find yourself prepending the same prefix for to your custom signals or parameters, 
+you can optionally configure `TelemetryDeck` to do this for you by activating our `DefaultPrefixProvider`:
+
+
+```kotlin
+// create an instance of [DefaultPrefixProvider] with a signal or parameter prefix
+val provider = DefaultPrefixProvider("MyApp.", "MyApp.Params.")
+
+// add the provider when configuring an instance of TelemetryDeck
+
+val builder = TelemetryDeck.Builder()
+    .appID("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
+    .addProvider(provider)
+```
+
 ## Custom Telemetry
 
 Another way to send signals is to register a custom `TelemetryDeckProvider`.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ You can also completely disable or override the default providers with your own.
 - `EnvironmentParameterProvider` - Adds environment and device information to outgoing Signals. This provider overrides the `enrich` method in order to append additional metadata for all signals before sending them.
 - `PlatformContextProvider` - Adds environment and device information which may change over time like the current timezone and screen metrics.
 
+For a complete list, check the `com.telemetrydeck.sdk.providers` package.
+
 ```kotlin
 // Append a custom provider
 val builder = TelemetryDeck.Builder()
@@ -334,7 +336,6 @@ After:
 
 
 ### Custom Telemetry
-
 
 Your custom providers must replace `TelemetryProvider` with `TelemetryDeckProvider`.
 

--- a/lib/src/main/java/com/telemetrydeck/sdk/SignalTransform.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/SignalTransform.kt
@@ -1,0 +1,3 @@
+package com.telemetrydeck.sdk
+
+data class SignalTransform(val signalType: String, val clientUser: String?, val additionalPayload: Map<String, String>, val floatValue: Double?)

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckProvider.kt
@@ -21,7 +21,7 @@ interface TelemetryDeckProvider {
      * A provider can override this method in order to append or remove telemetry metadata from Signals
      * before they are enqueued for broadcast.
      *
-     * TelemetryManager calls this method all providers in order of registration.
+     * TelemetryManager calls this method on all providers in order of registration.
      */
     fun enrich(
         signalType: String,
@@ -30,4 +30,17 @@ interface TelemetryDeckProvider {
     ): Map<String, String> {
         return additionalPayload
     }
+
+    /**
+     * A provider can override this method in order apply a transformation on any part of the signal, including the signal name.
+     * [TelemetryDeck] calls this method on all providers in order of registration.
+     *
+     * This method is always called **after** [enrich].
+     */
+    fun transform(
+        signalTransform: SignalTransform
+    ): SignalTransform {
+        return signalTransform
+    }
 }
+

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/DefaultPrefixProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/DefaultPrefixProvider.kt
@@ -1,0 +1,60 @@
+package com.telemetrydeck.sdk.providers
+
+import android.app.Application
+import com.telemetrydeck.sdk.SignalTransform
+import com.telemetrydeck.sdk.TelemetryDeckProvider
+import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
+
+
+/**
+ * [DefaultPrefixProvider] is a [TelemetryDeckProvider] that adds a default prefix to all outgoing signals or parameters.
+ *
+ * For example, if you are already adding `AppName.` in front of every signal or parameter, just specify it here and no need to repeat over and over again.
+ *
+ * This provider ignores signals and parameters in the `TelemetryDeck` namespace.
+ *
+ * @property defaultSignalPrefix Specify this if you want us to prefix all your signals with a specific text.
+ * @property defaultParameterPrefix Specify this if you want us to prefix all your signal parameters with a specific text.
+ */
+class DefaultPrefixProvider(val defaultSignalPrefix: String?, val defaultParameterPrefix: String?) :
+    TelemetryDeckProvider {
+    override fun register(ctx: Application?, client: TelemetryDeckSignalProcessor) {
+        // nothing to do
+    }
+
+    override fun stop() {
+        // nothing to do
+    }
+
+    override fun transform(signalTransform: SignalTransform): SignalTransform {
+        val paramPrefix = defaultParameterPrefix
+        val signalPrefix = defaultSignalPrefix
+
+        if (paramPrefix == null && signalPrefix == null) {
+            // nothing to do
+            return signalTransform
+        }
+
+        var transform =
+            signalTransform.copy(additionalPayload = signalTransform.additionalPayload.toMutableMap())
+
+        if (paramPrefix != null) {
+            transform =
+                transform.copy(additionalPayload = transform.additionalPayload
+                    .map {
+                        if (!it.key.startsWith("TelemetryDeck.")) {
+                            ("$paramPrefix${it.key}" to it.value)
+                        } else {
+                            // do not prefix our own signals
+                            (it.key to it.value)
+                        }
+                    }.toMap())
+        }
+
+        if (signalPrefix != null && !transform.signalType.startsWith("TelemetryDeck.")) {
+            transform = transform.copy(signalType = "$signalPrefix${transform.signalType}")
+        }
+
+        return transform
+    }
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -2,6 +2,7 @@ package com.telemetrydeck.sdk
 
 import android.app.Application
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.telemetrydeck.sdk.providers.DefaultPrefixProvider
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -431,6 +432,23 @@ class TelemetryDeckTests {
 
         val queuedSignal = telemetryDeck.cache?.empty()?.first()
         Assert.assertEquals(hashString("always the same"), queuedSignal?.clientUser)
+    }
+
+    @Test
+    fun telemetryDeck_default_prefix_provider() {
+        val config = TelemetryManagerConfiguration("32CB6574-6732-4238-879F-582FEBEB6536")
+        val manager = TelemetryDeck.Builder().addProvider(DefaultPrefixProvider("SignalPrefix.", "ParamPrefix.")).configuration(config).build(null)
+
+        manager.signal("test", mapOf("param1" to "value1"), floatValue = 1.0)
+
+        val queuedSignal = manager.cache?.empty()?.first()
+
+        Assert.assertNotNull(queuedSignal)
+
+        // validate the signal type
+        Assert.assertEquals("SignalPrefix.test", queuedSignal?.type)
+        Assert.assertEquals(1.0, queuedSignal?.floatValue)
+        Assert.assertEquals("ParamPrefix.param1:value1", queuedSignal?.payload?.firstOrNull { it.startsWith("ParamPrefix.") }, )
     }
 
     private fun hashString(input: String, algorithm: String = "SHA-256"): String {

--- a/lib/src/test/java/com/telemetrydeck/sdk/providers/DefaultPrefixProviderTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/providers/DefaultPrefixProviderTest.kt
@@ -1,0 +1,66 @@
+package com.telemetrydeck.sdk.providers
+
+
+import com.telemetrydeck.sdk.SignalTransform
+import org.junit.Assert
+import org.junit.Test
+
+class DefaultPrefixProviderTest {
+
+    private fun exampleSignal(type: String = "signal", param: String = "key1"): SignalTransform {
+        return SignalTransform(type, "user1", mapOf(param to "value1"), 2.0)
+    }
+
+    @Test
+    fun default_prefix_provider_no_effect_when_both_prefix_null() {
+        val signal = exampleSignal()
+        val sut = DefaultPrefixProvider(null, null)
+        val result = sut.transform(signal)
+        Assert.assertEquals(signal, result)
+    }
+
+    @Test
+    fun default_prefix_provider_signal_prefix() {
+        val signal = exampleSignal()
+        val sut = DefaultPrefixProvider("Signal.", null)
+        val result = sut.transform(signal)
+        val expected = exampleSignal("Signal.signal")
+        Assert.assertEquals(expected, result)
+    }
+
+    @Test
+    fun default_prefix_provider_param_prefix() {
+        val signal = exampleSignal()
+        val sut = DefaultPrefixProvider(null, "Param.")
+        val result = sut.transform(signal)
+        val expected = exampleSignal(param = "Param.key1")
+        Assert.assertEquals(expected, result)
+    }
+
+    @Test
+    fun default_prefix_provider_signal_and_param_prefix() {
+        val signal = exampleSignal()
+        val sut = DefaultPrefixProvider("Signal.", "Param.")
+        val result = sut.transform(signal)
+        val expected = exampleSignal(type = "Signal.signal", param = "Param.key1")
+        Assert.assertEquals(expected, result)
+    }
+
+    @Test
+    fun default_prefix_provider_ignores_telemetrydeck_signals() {
+        val signal = exampleSignal("TelemetryDeck.SDK.name")
+        val sut = DefaultPrefixProvider("Signal.", "Param.")
+        val result = sut.transform(signal)
+        val expected = exampleSignal(type = "TelemetryDeck.SDK.name", param = "Param.key1")
+        Assert.assertEquals(expected, result)
+    }
+
+    @Test
+    fun default_prefix_provider_ignores_telemetrydeck_params() {
+        val signal = exampleSignal(param = "TelemetryDeck.something")
+        val sut = DefaultPrefixProvider("Signal.", "Param.")
+        val result = sut.transform(signal)
+        val expected = exampleSignal(type = "Signal.signal", param = "TelemetryDeck.something")
+        Assert.assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
This PR fixes #55 and fixes #56 by making it possible to define a default prefix for signals and/or parameters. The TelemetryDeck namespace is ignored.

The feature is opt-in and can be enabled by adding our default prefix provider:


```kotlin
val builder = TelemetryDeck.Builder()
    .appID("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
    .addProvider(DefaultPrefixProvider("MyApp.", "MyApp.Params."))
```

With this PR, the provider interface has been extended to allow custom plugins to transform any part of a Signal and not just the additional payload.