### PR TITLE
Signal when a new installation has been detected

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+ignore:
+  paths:
+    - README.md
+
 # prevent concurrent builds from running at the same time
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,9 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'README.md'
 
-ignore:
-  paths:
-    - README.md
 
 # prevent concurrent builds from running at the same time
 concurrency:

--- a/README.md
+++ b/README.md
@@ -129,47 +129,55 @@ TelemetryDeck.start(applicationContext, builder)
 
 By default, Kotlin SDK for TelemetryDeck will include the following environment parameters for each outgoing signal
 
-| Parameter name                                                | Provider                       | Description                                        |
-|---------------------------------------------------------------|--------------------------------|----------------------------------------------------|
-| `TelemetryDeck.Session.started`                               | `SessionAppProvider`           |                                                    |
-| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.architecture`                           | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.modelName`                              | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.operatingSystem`                        | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.platform`                               | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.systemMajorMinorVersion`                | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.systemMajorVersion`                     | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.systemVersion`                          | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.orientation`                            | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.Device.screenDensity`                          | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.Device.screenResolutionHeight`                 | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.Device.screenResolutionWidth`                  | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.Device.brand`                                  | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.Device.timeZone`                               | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.SDK.name`                                      | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.SDK.version`                                   | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.SDK.nameAndVersion`                            | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.SDK.buildType`                                 | `EnvironmentParameterProvider` |                                                    |
-| `TelemetryDeck.RunContext.locale`                             | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.RunContext.targetEnvironment`                  | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.RunContext.isSideLoaded`                       | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.RunContext.sourceMarketplace`                  | `PlatformContextProvider`      |                                                    |
-| `TelemetryDeck.Accessibility.isBoldTextEnabled`               | `AccessibilityProvider`        | API 31 and above                                   |
-| `TelemetryDeck.Accessibility.fontWeightAdjustment`            | `AccessibilityProvider`        | API 31 and above                                   |
-| `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`     | `AccessibilityProvider`        |                                                    |
-| `TelemetryDeck.Accessibility.fontScale`                       | `AccessibilityProvider`        | Mapped to iOS size categories                      |
-| `TelemetryDeck.Accessibility.isInvertColorsEnabled`           | `AccessibilityProvider`        |                                                    |
-| `TelemetryDeck.Accessibility.isReduceMotionEnabled`           | `AccessibilityProvider`        |                                                    |
-| `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`     | `AccessibilityProvider`        |                                                    |
-| `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` | `AccessibilityProvider`        |                                                    |
-| `TelemetryDeck.UserPreference.layoutDirection`                | `AccessibilityProvider`        | Possible values are "rightToLeft" or "leftToRight" |
+| Parameter name                                                | Provider                        | Description                                        |
+|---------------------------------------------------------------|---------------------------------|----------------------------------------------------|
+| `TelemetryDeck.Session.started`                               | `SessionAppProvider`            |                                                    |
+| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.architecture`                           | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.modelName`                              | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.operatingSystem`                        | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.platform`                               | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.systemMajorMinorVersion`                | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.systemMajorVersion`                     | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.systemVersion`                          | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.orientation`                            | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.Device.screenDensity`                          | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.Device.screenResolutionHeight`                 | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.Device.screenResolutionWidth`                  | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.Device.brand`                                  | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.Device.timeZone`                               | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.AppInfo.buildNumber`                           | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.AppInfo.version`                               | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.AppInfo.versionAndBuildNumber`                 | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.SDK.name`                                      | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.SDK.version`                                   | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.SDK.nameAndVersion`                            | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.SDK.buildType`                                 | `EnvironmentParameterProvider`  |                                                    |
+| `TelemetryDeck.RunContext.locale`                             | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.RunContext.targetEnvironment`                  | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.RunContext.isSideLoaded`                       | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.RunContext.sourceMarketplace`                  | `PlatformContextProvider`       |                                                    |
+| `TelemetryDeck.Accessibility.isBoldTextEnabled`               | `AccessibilityProvider`         | API 31 and above                                   |
+| `TelemetryDeck.Accessibility.fontWeightAdjustment`            | `AccessibilityProvider`         | API 31 and above                                   |
+| `TelemetryDeck.Accessibility.isDarkerSystemColorsEnabled`     | `AccessibilityProvider`         |                                                    |
+| `TelemetryDeck.Accessibility.fontScale`                       | `AccessibilityProvider`         | Mapped to iOS size categories                      |
+| `TelemetryDeck.Accessibility.isInvertColorsEnabled`           | `AccessibilityProvider`         |                                                    |
+| `TelemetryDeck.Accessibility.isReduceMotionEnabled`           | `AccessibilityProvider`         |                                                    |
+| `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`     | `AccessibilityProvider`         |                                                    |
+| `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` | `AccessibilityProvider`         |                                                    |
+| `TelemetryDeck.UserPreference.layoutDirection`                | `AccessibilityProvider`         | Possible values are "rightToLeft" or "leftToRight" |
+| `TelemetryDeck.Acquisition.newInstallDetected`                | `SessionTrackingSignalProvider` |                                                    |
 
 #### Notes 
+
+- `TelemetryDeck.Acquisition.newInstallDetected`
+
+We send this signal when a user starts the app for the first time on a given device.
+
+- Session data is stored locally on device as part of the application's files.
+- If the application is uninstalled or it's data cleared, the SDK will report a new installation event (we do not bridge session data of any kind between installations)
 
 - `TelemetryDeck.Accessibility.fontScale` - the value is mapped to better align with size categories sent by other SDKs:
 
@@ -303,7 +311,8 @@ You can also completely disable or override the default providers with your own.
 - `EnvironmentParameterProvider` - Adds environment and device information to outgoing Signals. This provider overrides the `enrich` method in order to append additional metadata for all signals before sending them.
 - `PlatformContextProvider` - Adds environment and device information which may change over time like the current timezone and screen metrics.
 - `AccessibilityProvider` - Adds parameters describing the currently active accessibility options.
-- 
+- `SessionTrackingSignalProvider` - Reports when a new app installation has been detected. 
+
 For a complete list, check the `com.telemetrydeck.sdk.providers` package.
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This package allows you to send signals to [TelemetryDeck](https://telemetrydeck
 * [Custom Telemetry](#custom-telemetry)
 * [Custom Logging](#custom-logging)
 * [Requirements](#requirements)
+* [Migrating providers to 5.0+](#migrating-providers-to-50)
 * [Migrating providers to 3.0+](#migrating-providers-to-30)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Kotlin SDK for TelemetryDeck is available from Maven Central and can be used
 
 ```groovy
 dependencies {
-    implementation 'com.telemetrydeck:kotlin-sdk:4.1.0'
+    implementation 'com.telemetrydeck:kotlin-sdk:5.0.0'
 }
 ```
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -100,7 +100,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.telemetrydeck", "kotlin-sdk", "4.1.0")
+    coordinates("com.telemetrydeck", "kotlin-sdk", "5.0.0")
 
     pom {
         name = "TelemetryDeck SDK"

--- a/lib/src/main/java/com/telemetrydeck/sdk/DateSerializer.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/DateSerializer.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package com.telemetrydeck.sdk
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
@@ -9,6 +12,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
+
 
 @Serializer(forClass = Date::class)
 internal object DateSerializer : KSerializer<Date> {

--- a/lib/src/main/java/com/telemetrydeck/sdk/SignalPayload.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/SignalPayload.kt
@@ -1,5 +1,6 @@
 package com.telemetrydeck.sdk
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.properties.Properties
 import kotlinx.serialization.properties.encodeToStringMap
@@ -9,6 +10,7 @@ data class SignalPayload(
     var additionalPayload: Map<String, String> = emptyMap()
 ) {
 
+    @OptIn(ExperimentalSerializationApi::class)
     private val asMap: Map<String, Any> by lazy {
         Properties.encodeToStringMap(this).filterKeys { !it.startsWith("additionalPayload") }
     }

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -9,6 +9,7 @@ import com.telemetrydeck.sdk.providers.EnvironmentParameterProvider
 import com.telemetrydeck.sdk.providers.FileUserIdentityProvider
 import com.telemetrydeck.sdk.providers.PlatformContextProvider
 import com.telemetrydeck.sdk.providers.SessionAppProvider
+import com.telemetrydeck.sdk.providers.SessionTrackingSignalProvider
 import java.lang.ref.WeakReference
 import java.net.URL
 import java.security.MessageDigest
@@ -217,7 +218,8 @@ class TelemetryDeck(
                 SessionAppProvider(),
                 EnvironmentParameterProvider(),
                 PlatformContextProvider(),
-                AccessibilityProvider()
+                AccessibilityProvider(),
+                SessionTrackingSignalProvider()
             )
         internal val alwaysOnProviders = listOf(DurationSignalTrackerProvider())
 

--- a/lib/src/main/java/com/telemetrydeck/sdk/UUIDSerializer.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/UUIDSerializer.kt
@@ -1,6 +1,7 @@
 package com.telemetrydeck.sdk
 
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
@@ -8,6 +9,7 @@ import kotlinx.serialization.encoding.Encoder
 import java.util.UUID
 
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializer(forClass = UUID::class)
 internal object UUIDSerializer : KSerializer<UUID> {
     override fun serialize(encoder: Encoder, value: UUID) {

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Acquisition.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Acquisition.kt
@@ -1,0 +1,5 @@
+package com.telemetrydeck.sdk.params
+
+enum class Acquisition(val paramName: String) {
+    FirstSessionDate("TelemetryDeck.Acquisition.firstSessionDate"),
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/DurationSignalTrackerProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/DurationSignalTrackerProvider.kt
@@ -7,11 +7,10 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.telemetrydeck.sdk.DateSerializer
 import com.telemetrydeck.sdk.TelemetryDeckProvider
 import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
+import com.telemetrydeck.sdk.providers.helpers.restoreStateFromDisk
+import com.telemetrydeck.sdk.providers.helpers.writeStateToDisk
 import com.telemetrydeck.sdk.signals.Signal
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import java.io.File
 import java.lang.ref.WeakReference
 import java.util.Date
 
@@ -25,7 +24,6 @@ class DurationSignalTrackerProvider : TelemetryDeckProvider, DefaultLifecycleObs
     override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
         this.manager = WeakReference(client)
         this.appContext = WeakReference(ctx)
-        this.state = restoreStateFromDisk() ?: TrackerState(emptyMap())
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     }
 
@@ -42,22 +40,28 @@ class DurationSignalTrackerProvider : TelemetryDeckProvider, DefaultLifecycleObs
     }
 
     fun handleOnStart() {
+        this.manager?.get()?.debugLogger?.debug("Commencing signal duration tracking")
+
         val preRestoreState = this.state
         if (preRestoreState == null) {
             // no state present in memory, restore it
-            val restoredState = restoreStateFromDisk()
+            val restoredState = restoreStateFromDisk<TrackerState?>(
+                this.appContext?.get(),
+                this.fileName,
+                this.fileEncoding,
+                this.manager?.get()?.debugLogger
+            )
             this.state = restoredState
         }
 
-        var currentState = this.state
-            ?: // nothing to do, probably not started yet
-            return
+        var currentState = this.state ?: TrackerState(emptyMap())
 
         val lastEnteredBackground = currentState.lastEnteredBackground
         if (lastEnteredBackground != null) {
             // subtracts background time from all signals by moving their start time forward
             val now = Date()
             val backgroundDuration = now.time - lastEnteredBackground.time
+            this.manager?.get()?.debugLogger?.debug("Adapting signal duration with -$backgroundDuration ms")
             currentState = currentState.copy(
                 signals = currentState.signals.mapValues {
                     it.value.copy(
@@ -67,14 +71,18 @@ class DurationSignalTrackerProvider : TelemetryDeckProvider, DefaultLifecycleObs
             )
         }
 
-        writeStateToDisk(currentState)
+        writeStateToDisk(currentState, this.appContext?.get(), this.fileName, this.fileEncoding, this.manager?.get()?.debugLogger)
         this.state = currentState
     }
 
     fun handleOnStop() {
+        this.manager?.get()?.debugLogger?.debug("Signal duration tracking is shutting down")
         val currentState = this.state
         if (currentState != null) {
-            writeStateToDisk(currentState)
+            val updatedState = currentState.copy(
+                lastEnteredBackground = Date()
+            )
+            writeStateToDisk(updatedState, this.appContext?.get(), this.fileName, this.fileEncoding, this.manager?.get()?.debugLogger)
         }
     }
 
@@ -117,34 +125,8 @@ class DurationSignalTrackerProvider : TelemetryDeckProvider, DefaultLifecycleObs
        return mergedParameters
     }
 
-    private fun restoreStateFromDisk(): TrackerState? {
-        val context = this.appContext?.get() ?: return null
-        try {
-            val file = File(context.filesDir, fileName)
-            if (file.exists()) {
-                val json = file.readText(fileEncoding)
-                val state = Json.decodeFromString<TrackerState>(json)
-                return state
-            }
-        } catch (e: Exception) {
-            this.manager?.get()?.debugLogger?.error("failed to restore duration tracking state ${e.stackTraceToString()}")
-        }
-        return null
-    }
 
-    private fun writeStateToDisk(state: TrackerState) {
-        val context = this.appContext?.get() ?: return
-        try {
-            val file = File(context.filesDir, fileName)
-            if (file.exists()) {
-                file.delete()
-            }
-            val json = Json.encodeToString(state)
-            file.writeText(json, fileEncoding)
-        } catch (e: Exception) {
-            this.manager?.get()?.debugLogger?.error("failed to write duration tracking state ${e.stackTraceToString()}")
-        }
-    }
+
 
     @Serializable
     data class TrackerState(

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/DurationSignalTrackerProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/DurationSignalTrackerProvider.kt
@@ -24,6 +24,12 @@ class DurationSignalTrackerProvider : TelemetryDeckProvider, DefaultLifecycleObs
     override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
         this.manager = WeakReference(client)
         this.appContext = WeakReference(ctx)
+        this.state = restoreStateFromDisk<TrackerState?>(
+            this.appContext?.get(),
+            this.fileName,
+            this.fileEncoding,
+            this.manager?.get()?.debugLogger
+        ) ?: TrackerState(emptyMap())
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     }
 

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
@@ -29,7 +29,7 @@ class EnvironmentParameterProvider : TelemetryDeckProvider {
     private val platform: String = "Android"
     private val os: String = "Android"
     private val sdkName: String = "KotlinSDK"
-    private val sdkVersion: String = "4.1.0"
+    private val sdkVersion: String = "5.0.0"
 
     override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
         appendContextSpecificParams(ctx, client.debugLogger)

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
@@ -19,7 +19,7 @@ import com.telemetrydeck.sdk.params.SDK
  * - information about the device running the application, such as operating system, model name, or architecture.
  * - information about the TelemetryDeck SDK, such as its name or version number.
  */
-internal class EnvironmentParameterProvider : TelemetryDeckProvider {
+class EnvironmentParameterProvider : TelemetryDeckProvider {
     private var enabled: Boolean = true
     private var metadata = mutableMapOf<String, String>()
 

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/PlatformContextProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/PlatformContextProvider.kt
@@ -12,7 +12,7 @@ import com.telemetrydeck.sdk.platform.getLocaleName
 import com.telemetrydeck.sdk.platform.getTimeZone
 import java.lang.ref.WeakReference
 
-internal class PlatformContextProvider : TelemetryDeckProvider {
+class PlatformContextProvider : TelemetryDeckProvider {
     private var enabled: Boolean = true
     private var manager: WeakReference<TelemetryDeckSignalProcessor>? = null
     private var appContext: WeakReference<Context?>? = null

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionAppProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionAppProvider.kt
@@ -13,7 +13,7 @@ import java.lang.ref.WeakReference
 /**
  * Monitors the app lifecycle in order to broadcast the NewSessionBegan signal.
  */
-internal class SessionAppProvider : TelemetryDeckProvider, DefaultLifecycleObserver {
+class SessionAppProvider : TelemetryDeckProvider, DefaultLifecycleObserver {
     private var manager: WeakReference<TelemetryDeckSignalProcessor>? = null
 
     override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProvider.kt
@@ -1,0 +1,136 @@
+package com.telemetrydeck.sdk.providers
+
+import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.telemetrydeck.sdk.DateSerializer
+import com.telemetrydeck.sdk.TelemetryDeckProvider
+import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
+import com.telemetrydeck.sdk.providers.helpers.restoreStateFromDisk
+import com.telemetrydeck.sdk.providers.helpers.writeStateToDisk
+import com.telemetrydeck.sdk.signals.Acquisition
+import kotlinx.serialization.Serializable
+import java.lang.ref.WeakReference
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/*
+*
+* Keeps track of user sessions and provides for TelemetryDeck.Acquisition.firstSessionDate
+* */
+class SessionTrackingSignalProvider: TelemetryDeckProvider, DefaultLifecycleObserver {
+    private var appContext: WeakReference<Context?>? = null
+    private var manager: WeakReference<TelemetryDeckSignalProcessor>? = null
+    private var state: TrackingState? = null
+    private val fileName = "telemetrydeckstracking"
+    private val fileEncoding = Charsets.UTF_8
+    private val dateFormat: DateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+
+    override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
+        this.manager = WeakReference(client)
+        this.appContext = WeakReference(ctx)
+        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+    }
+
+    override fun stop() {
+        // nothing to do
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        handleOnStart()
+    }
+
+    fun handleOnStart() {
+        this.manager?.get()?.debugLogger?.debug("Commencing session tracking")
+        val preRestoreState = this.state
+        if (preRestoreState == null) {
+            // no state present in memory, restore it
+            val restoredState = restoreStateFromDisk<TrackingState?>(
+                this.appContext?.get(),
+                this.fileName,
+                this.fileEncoding,
+                this.manager?.get()?.debugLogger
+            )
+            this.state = restoredState
+        }
+
+        val currentState = this.state ?: TrackingState(emptyList(), emptyList())
+
+        this.manager?.get()?.debugLogger?.debug("Session tracking restoring sessions")
+        val now = Date()
+        val today = dateFormat.format(now)
+        if (currentState.sessions.isEmpty()) {
+            // we're running for the first time
+            this.manager?.get()?.debugLogger?.debug("Session tracking is running for the first time")
+            manager?.get()?.processSignal(
+                Acquisition.NewInstallDetected.signalName,
+                mapOf(
+                    com.telemetrydeck.sdk.params.Acquisition.FirstSessionDate.paramName to today
+                )
+            )
+        }
+
+        // start a new session
+        val newSession = StoredSession(now, null, 0)
+        val updatedState = currentState.copy(
+            sessions = currentState.sessions + newSession,
+            distinctDays = (currentState.distinctDays + today).distinctBy { it.lowercase() }
+        )
+
+        this.manager?.get()?.debugLogger?.debug("Session tracking ${updatedState.sessions.size} sessions.")
+        writeStateToDisk(updatedState, this.appContext?.get(), this.fileName, this.fileEncoding, this.manager?.get()?.debugLogger)
+        this.state = updatedState
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        handleOnStop()
+    }
+
+    fun handleOnStop() {
+        this.manager?.get()?.debugLogger?.debug("Session tracking is shutting down")
+        var currentState = this.state
+        if (currentState != null) {
+            val lastSession = currentState.sessions.lastOrNull()
+            val now = Date()
+            val today = dateFormat.format(now)
+            if (lastSession != null) {
+                // mark the session as ended and calculate the duration
+                this.manager?.get()?.debugLogger?.debug("Session tracking finalizing current session")
+
+                val durationMillis = now.time - lastSession.firstStart.time
+                currentState = currentState.copy(
+                    sessions = currentState.sessions.dropLast(1) + lastSession.copy(ended = now, durationMillis = durationMillis),
+                )
+            }
+
+            // update distinct days (e.g. in case we've changed timezone or it's already tomorrow
+            currentState = currentState.copy(
+                distinctDays = (currentState.distinctDays + today).distinctBy { it.lowercase() }
+            )
+
+            writeStateToDisk(currentState, this.appContext?.get(), this.fileName, this.fileEncoding, this.manager?.get()?.debugLogger)
+        } else {
+            this.manager?.get()?.debugLogger?.debug("Session tracking has no current state, nothing to do")
+        }
+    }
+
+    @Serializable
+    data class StoredSession(
+        @Serializable(with = DateSerializer::class)
+        val firstStart: Date,
+        @Serializable(with = DateSerializer::class)
+        val ended: Date?,
+        // The duration of the session covering the time when the user was actively interacting with the app (based on the app's lifecycle)
+        val durationMillis: Long
+    )
+
+    @Serializable
+    data class TrackingState(
+        val sessions: List<StoredSession>,
+        // A list of dates on which we have seen the user
+        val distinctDays: List<String>,
+    )
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProvider.kt
@@ -1,7 +1,6 @@
 package com.telemetrydeck.sdk.providers
 
 import android.content.Context
-import android.icu.util.Calendar
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/helpers/ProviderDiskTools.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/helpers/ProviderDiskTools.kt
@@ -1,0 +1,47 @@
+package com.telemetrydeck.sdk.providers.helpers
+
+import android.content.Context
+import com.telemetrydeck.sdk.DebugLogger
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.nio.charset.Charset
+
+
+internal inline fun <reified T> restoreStateFromDisk(
+    appContext: Context?,
+    fileName: String,
+    fileEncoding: Charset = Charsets.UTF_8,
+    logger: DebugLogger?
+): T? {
+    val context = appContext ?: return null
+    try {
+        val file = File(context.filesDir, fileName)
+        if (file.exists()) {
+            val json = file.readText(fileEncoding)
+            val state = Json.decodeFromString<T>(json)
+            return state
+        }
+    } catch (e: Exception) {
+        logger?.error("failed to restore state ${e.stackTraceToString()}")
+    }
+    return null
+}
+
+internal inline fun <reified T> writeStateToDisk(state: T,
+                                                 appContext: Context?,
+                                                 fileName: String,
+                                                 fileEncoding: Charset = Charsets.UTF_8,
+                                                 logger: DebugLogger?) {
+    val context = appContext ?: return
+    try {
+        val file = File(context.filesDir, fileName)
+        if (file.exists()) {
+            file.delete()
+        }
+        val json = Json.encodeToString(state)
+        file.writeText(json, fileEncoding)
+    } catch (e: Exception) {
+        logger?.error("failed to write state ${e.stackTraceToString()}")
+    }
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/signals/Acquisition.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/signals/Acquisition.kt
@@ -1,0 +1,5 @@
+package com.telemetrydeck.sdk.signals
+
+internal enum class Acquisition(val signalName: String) {
+    NewInstallDetected("TelemetryDeck.Acquisition.newInstallDetected"),
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -245,7 +245,7 @@ class TelemetryDeckTests {
             .build(null)
         sut.signal("type")
 
-        Assert.assertEquals(5 + 1, sut.providers.count()) // default ones + the one added in the test
+        Assert.assertEquals(6 + 1, sut.providers.count()) // default ones + the one added in the test
         Assert.assertTrue(sut.providers.last() is TestTelemetryDeckProvider)
     }
 


### PR DESCRIPTION
This PR fixes #52 by introducing a mechanism for tracking the first device installation. 

* The session cutoff of 90 days was carried over [from the SwiftSDK](https://github.com/TelemetryDeck/SwiftSDK/pull/230/files#diff-d964ee4356bcf74d21105bc76e8633ddfdd0453a3ab7e79e2133699c345b183cR111).
* The new tracking provider is on by default.

Note: additional averages, distinct days and other KPIs are not being submitted yet - this will come in a next release.

