### PR TITLE
Fix: Cache should be available to providers during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Kotlin SDK for TelemetryDeck is available from Maven Central and can be used
 
 ```groovy
 dependencies {
-    implementation 'com.telemetrydeck:kotlin-sdk:5.0.0'
+    implementation 'com.telemetrydeck:kotlin-sdk:5.0.1'
 }
 ```
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -100,7 +100,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.telemetrydeck", "kotlin-sdk", "5.0.0")
+    coordinates("com.telemetrydeck", "kotlin-sdk", "5.0.1")
 
     pom {
         name = "TelemetryDeck SDK"

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -529,7 +529,6 @@ class TelemetryDeck(
 
             val manager = TelemetryDeck(config, providers)
             manager.logger = logger
-            manager.installProviders(context)
 
             val broadcaster =
                 TelemetryBroadcastTimer(WeakReference(manager), WeakReference(manager.logger))
@@ -547,6 +546,9 @@ class TelemetryDeck(
                 manager.identityProvider = userIdentityProvider
             }
 
+            // providers must be installed at the end to allow them access to cache and full signal processing
+            manager.installProviders(context)
+            
             return manager
         }
     }

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
@@ -29,7 +29,7 @@ class EnvironmentParameterProvider : TelemetryDeckProvider {
     private val platform: String = "Android"
     private val os: String = "Android"
     private val sdkName: String = "KotlinSDK"
-    private val sdkVersion: String = "5.0.0"
+    private val sdkVersion: String = "5.0.1"
 
     override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
         appendContextSpecificParams(ctx, client.debugLogger)


### PR DESCRIPTION
This PR addresses a situation where providers may attempt to send signals before TelemetryDeck is ready to do so. This was detected in the FlutterSDK when adopting version 5.0.0.