### PR TITLE
Add additional UserPreference parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ By default, Kotlin SDK for TelemetryDeck will include the following environment 
 | `TelemetryDeck.Accessibility.isReduceTransparencyEnabled`     | `AccessibilityProvider`         |                                                    |
 | `TelemetryDeck.Accessibility.shouldDifferentiateWithoutColor` | `AccessibilityProvider`         |                                                    |
 | `TelemetryDeck.UserPreference.layoutDirection`                | `AccessibilityProvider`         | Possible values are "rightToLeft" or "leftToRight" |
+| `TelemetryDeck.UserPreference.region`                         | `AccessibilityProvider`         | Current device region in ISO 3166-1 alpha-2 format |
+| `TelemetryDeck.UserPreference.language`                       | `AccessibilityProvider`         | Current application language in ISO 639-1 format   |
+| `TelemetryDeck.UserPreference.colorScheme`                    | `AccessibilityProvider`         | "Dark" or "Light"                                  |
 | `TelemetryDeck.Acquisition.newInstallDetected`                | `SessionTrackingSignalProvider` |                                                    |
 
 #### Notes 

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/AccessibilityProviderTest.kt
@@ -31,5 +31,8 @@ class AccessibilityProviderEnrichmentParametersTest {
         assertTrue(result.containsKey("TelemetryDeck.Accessibility.isReduceMotionEnabled"))
         assertTrue(result.containsKey("TelemetryDeck.Accessibility.isReduceTransparencyEnabled"))
         assertTrue(result.containsKey("TelemetryDeck.UserPreference.layoutDirection"))
+        assertTrue(result.containsKey("TelemetryDeck.UserPreference.region"))
+        assertTrue(result.containsKey("TelemetryDeck.UserPreference.language"))
+        assertTrue(result.containsKey("TelemetryDeck.UserPreference.colorScheme"))
     }
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/UserPreference.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/UserPreference.kt
@@ -1,5 +1,8 @@
 package com.telemetrydeck.sdk.params
 
-enum class UserPreferences(val paramName: String) {
+internal enum class UserPreferences(val paramName: String) {
     LayoutDirection("TelemetryDeck.UserPreference.layoutDirection"),
+    Region("TelemetryDeck.UserPreference.region"),
+    Language("TelemetryDeck.UserPreference.language"),
+    ColorScheme("TelemetryDeck.UserPreference.colorScheme"),
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/AccessibilityProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/AccessibilityProvider.kt
@@ -1,18 +1,16 @@
 package com.telemetrydeck.sdk.providers
 
 import android.content.Context
-import android.app.Application
 import android.content.res.Configuration
 import android.os.Build
 import android.provider.Settings
 import android.util.LayoutDirection
-import android.view.accessibility.AccessibilityManager
 import androidx.core.text.layoutDirection
 import com.telemetrydeck.sdk.TelemetryDeckProvider
 import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
 import com.telemetrydeck.sdk.params.Accessibility
-import com.telemetrydeck.sdk.params.Device
 import com.telemetrydeck.sdk.params.UserPreferences
+import com.telemetrydeck.sdk.providers.helpers.getCurrentAppLanguageAndRegion
 import java.lang.ref.WeakReference
 import java.util.Locale
 
@@ -64,7 +62,8 @@ class AccessibilityProvider : TelemetryDeckProvider {
 
         try {
             isDarkModeEnabled().let {
-                attributes[Accessibility.IsDarkerSystemColorsEnabled.paramName] = "$it"
+                attributes[Accessibility.IsDarkerSystemColorsEnabled.paramName] = "${it == true}"
+                attributes[UserPreferences.ColorScheme.paramName] = if (it == true) "Dark" else "Light"
             }
         } catch (e: Exception) {
             this.manager?.get()?.debugLogger?.error("Error detecting IsDarkerSystemColorsEnabled: ${e.stackTraceToString()}")
@@ -126,6 +125,14 @@ class AccessibilityProvider : TelemetryDeckProvider {
                     true -> "rightToLeft"
                     false -> "leftToRight"
                 }
+        } catch (e: Exception) {
+            this.manager?.get()?.debugLogger?.error("Error detecting LayoutDirection: ${e.stackTraceToString()}")
+        }
+
+        try {
+            val (language, region) = getCurrentAppLanguageAndRegion(context)
+            attributes[UserPreferences.Region.paramName] = region
+            attributes[UserPreferences.Language.paramName] = language
         } catch (e: Exception) {
             this.manager?.get()?.debugLogger?.error("Error detecting LayoutDirection: ${e.stackTraceToString()}")
         }

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/helpers/LocaleHelpers.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/helpers/LocaleHelpers.kt
@@ -1,0 +1,33 @@
+package com.telemetrydeck.sdk.providers.helpers
+
+import android.content.Context
+import android.os.Build
+import java.util.Locale
+
+/**
+ * Retrieves the current language and region set for the application.
+ *
+ * @param context The application context.
+ * @return A [Pair] containing the current language code (e.g., "en") as the first element
+ *         and the current region code (e.g., "US") as the second element.
+ *
+ * Example:
+ * ```kotlin
+ * val (language, region) = getCurrentAppLanguageAndRegion(applicationContext)
+ * println("Current language: $language") // Output: Current language: en (e.g)
+ * println("Current region: $region")   // Output: Current region: US (e.g)
+ * ```
+ *
+ * Note: The language and region codes are in the ISO 639-1 and ISO 3166-1 alpha-2 standards, respectively.
+ */
+internal fun getCurrentAppLanguageAndRegion(context: Context): Pair<String, String> {
+    val locale: Locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        context.resources.configuration.locales[0]
+    } else {
+        @Suppress("DEPRECATION")
+        context.resources.configuration.locale
+    }
+    val language: String = locale.language
+    val region: String = locale.country
+    return Pair(language, region)
+}


### PR DESCRIPTION
This PR fixes #60 by adding the following default parameters as part of Accessibility:

| Parameter name                                                | Provider                        | Description                                        |
|---------------------------------------------------------------|---------------------------------|----------------------------------------------------|
| `TelemetryDeck.UserPreference.region`                         | `AccessibilityProvider`         | Current device region in ISO 3166-1 alpha-2 format e.g. `GB` |
| `TelemetryDeck.UserPreference.language`                       | `AccessibilityProvider`         | Current application language in ISO 639-1 format e.g. `en`  |
| `TelemetryDeck.UserPreference.colorScheme`                    | `AccessibilityProvider`         | "Dark" or "Light"                                  |
