### PR TITLE
Add Calendar based default parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ outgoing signal
 | `TelemetryDeck.Retention.totalSessionsCount`                  | `SessionTrackingSignalProvider` |                                                    |
 | `TelemetryDeck.Retention.previousSessionSeconds`              | `SessionTrackingSignalProvider` |                                                    |
 | `TelemetryDeck.Retention.distinctDaysUsedLastMonth`           | `SessionTrackingSignalProvider` |                                                    |
+| `TelemetryDeck.Calendar.dayOfMonth`                           | `CalendarParameterProvider`     |                                                    |
+| `TelemetryDeck.Calendar.dayOfWeek`                            | `CalendarParameterProvider`     |                                                    |
+| `TelemetryDeck.Calendar.dayOfYear`                            | `CalendarParameterProvider`     |                                                    |
+| `TelemetryDeck.Calendar.weekOfYear`                           | `CalendarParameterProvider`     |                                                    |
+| `TelemetryDeck.Calendar.isWeekend`                            | `CalendarParameterProvider`     |                                                    |
+| `TelemetryDeck.Calendar.monthOfYear`                          | `CalendarParameterProvider`     |                                                    |
+| `TelemetryDeck.Calendar.quarterOfYear`                        | `CalendarParameterProvider`     |                                                    |
+| `TelemetryDeck.Calendar.hourOfDay`                            | `CalendarParameterProvider`     |                                                    |
 
 #### Notes
 
@@ -371,6 +379,19 @@ val builder = TelemetryDeck.Builder()
 
 * You can provide your own logic for session tracking by adopting
   `TelemetryDeckSessionManagerProvider` and setting it as the session manager.
+
+## Calendar Parameters
+
+By default, the KotlinSDK will append the following parameters to all outgoing signals:
+
+- `TelemetryDeck.Calendar.dayOfMonth`: The day-of-month (1..31) component of the date.
+- `TelemetryDeck.Calendar.dayOfWeek`: The ISO 8601 number of the given day of the week. Monday is 1, Sunday is 7.
+- `TelemetryDeck.Calendar.dayOfYear`: The 1-based day-of-year component of the date.
+- `TelemetryDeck.Calendar.weekOfYear`: The week number within the current year as defined by `getFirstDayOfWeek()` and `getMinimalDaysInFirstWeek()`.
+- `TelemetryDeck.Calendar.isWeekend`: `true` if the day of the week is Saturday or Sunday, `false` otherwise.
+- `TelemetryDeck.Calendar.monthOfYear`: The number-of-the-month (1..12) component of the date.
+- `TelemetryDeck.Calendar.quarterOfYear`: The the quarter-of-year (1..4). For API 26 and earlier, it's the number of the month divided by 3.
+- `TelemetryDeck.Calendar.hourOfDay`: The hour-of-day (0..23) time component of this time value.
 
 ## Custom Telemetry
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ appcompat = "1.7.0"
 mockk = "1.13.13"
 robolectric = "4.7.3"
 androidxTest = "1.6.1"
+datetime = "0.6.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -42,6 +43,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-serialization-properties = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-properties", version.ref = "kotlinx" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "datetime" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 mockk = {group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-agent = {group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.properties)
     implementation(libs.ktor.client.logging)
+    implementation(libs.kotlinx.datetime)
 
 
     testImplementation(libs.junit)

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import com.telemetrydeck.sdk.params.Navigation
 import com.telemetrydeck.sdk.providers.AccessibilityProvider
+import com.telemetrydeck.sdk.providers.CalendarParameterProvider
 import com.telemetrydeck.sdk.providers.DurationSignalTrackerProvider
 import com.telemetrydeck.sdk.providers.EnvironmentParameterProvider
 import com.telemetrydeck.sdk.providers.FileUserIdentityProvider
@@ -227,7 +228,8 @@ class TelemetryDeck(
             get() = listOf(
                 EnvironmentParameterProvider(),
                 PlatformContextProvider(),
-                AccessibilityProvider()
+                AccessibilityProvider(),
+                CalendarParameterProvider()
             )
         internal val alwaysOnProviders = listOf(DurationSignalTrackerProvider())
 

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Calendar.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Calendar.kt
@@ -1,0 +1,12 @@
+package com.telemetrydeck.sdk.params
+
+internal enum class Calendar(val paramName: String) {
+    DayOfMonth("TelemetryDeck.Calendar.dayOfMonth"),
+    DayOfWeek("TelemetryDeck.Calendar.dayOfWeek"),
+    DayOfYear("TelemetryDeck.Calendar.dayOfYear"),
+    WeekOfYear("TelemetryDeck.Calendar.weekOfYear"),
+    IsWeekend("TelemetryDeck.Calendar.isWeekend"),
+    MonthOfYear("TelemetryDeck.Calendar.monthOfYear"),
+    QuarterOfYear("TelemetryDeck.Calendar.quarterOfYear"),
+    HourOfDay("TelemetryDeck.Calendar.hourOfDay"),
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/platform/PlatformReader.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/platform/PlatformReader.kt
@@ -37,7 +37,6 @@ internal fun getPackageInfo(context: Context, logger: DebugLogger?): PackageInfo
                 .packageManager
                 .getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0))
         } else {
-            @Suppress("DEPRECATION")
             return context.packageManager.getPackageInfo(context.packageName, 0)
         }
     } catch (e: Exception) {
@@ -93,7 +92,7 @@ internal fun getDisplayMetrics(context: Context, logger: DebugLogger?): ScreenMe
     }
 }
 
-internal fun getLocaleName(context: Context, logger: DebugLogger?): String? {
+internal fun getCurrentLocale(context: Context, logger: DebugLogger?): Locale? {
     try {
         val currentLocale: Locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             context.resources.configuration.locales[0]
@@ -102,9 +101,13 @@ internal fun getLocaleName(context: Context, logger: DebugLogger?): String? {
             context.resources.configuration.locale
         }
 
-        return currentLocale.displayName
+        return currentLocale
     } catch (e: Exception) {
-        logger?.error("getLocaleName failed: $e ${e.stackTraceToString()}")
+        logger?.error("getLocale failed: $e ${e.stackTraceToString()}")
         return null
     }
+}
+
+internal fun getLocaleName(context: Context, logger: DebugLogger?): String? {
+    return getCurrentLocale(context, logger)?.displayName
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/CalendarParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/CalendarParameterProvider.kt
@@ -1,0 +1,78 @@
+package com.telemetrydeck.sdk.providers
+
+import android.content.Context
+import android.os.Build
+import com.telemetrydeck.sdk.TelemetryDeckProvider
+import com.telemetrydeck.sdk.TelemetryDeckSignalProcessor
+import com.telemetrydeck.sdk.platform.getCurrentLocale
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.toLocalDateTime
+import java.lang.ref.WeakReference
+import java.time.LocalDate
+import java.time.temporal.IsoFields
+import java.util.Calendar
+
+class CalendarParameterProvider : TelemetryDeckProvider {
+    private var app: WeakReference<Context?>? = null
+    private var manager: WeakReference<TelemetryDeckSignalProcessor>? = null
+
+    override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
+        this.app = WeakReference(ctx)
+        this.manager = WeakReference(client)
+    }
+
+    override fun stop() {
+        // nothing to do
+    }
+
+    override fun enrich(
+        signalType: String,
+        clientUser: String?,
+        additionalPayload: Map<String, String>
+    ): Map<String, String> {
+        val context = app?.get()
+
+        if (context == null) {
+            manager?.get()?.debugLogger?.error("CalendarParameterProvider: context is null")
+            return additionalPayload
+        }
+
+        val userLocale = getCurrentLocale(context, manager?.get()?.debugLogger)
+        if (userLocale == null) {
+            manager?.get()?.debugLogger?.error("CalendarParameterProvider: Locale is null")
+        }
+
+        val signalPayload = additionalPayload.toMutableMap()
+        val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        signalPayload[com.telemetrydeck.sdk.params.Calendar.DayOfMonth.paramName] = "${now.dayOfMonth}"
+        signalPayload[com.telemetrydeck.sdk.params.Calendar.DayOfWeek.paramName] = "${now.dayOfWeek.isoDayNumber}"
+        signalPayload[com.telemetrydeck.sdk.params.Calendar.DayOfYear.paramName] = "${now.dayOfYear}"
+        signalPayload[com.telemetrydeck.sdk.params.Calendar.MonthOfYear.paramName] = "${now.monthNumber}"
+        signalPayload[com.telemetrydeck.sdk.params.Calendar.HourOfDay.paramName] = "${now.hour}"
+
+        // Note: isWeekend only accounts for Sat-Sun counties
+        signalPayload[com.telemetrydeck.sdk.params.Calendar.IsWeekend.paramName] = "${now.dayOfWeek.isoDayNumber in listOf(6, 7)}"
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val currentDate = LocalDate.now()
+            signalPayload[com.telemetrydeck.sdk.params.Calendar.WeekOfYear.paramName] = "${Calendar.getInstance().get(Calendar.WEEK_OF_YEAR)}"
+            signalPayload[com.telemetrydeck.sdk.params.Calendar.QuarterOfYear.paramName] = "${currentDate.get(IsoFields.QUARTER_OF_YEAR)}"
+        } else {
+            // falling back to simple 3 month approach
+            val quarterNumber = when (now.monthNumber) {
+                in 1..3 -> 1
+                in 4..6 -> 2
+                in 7..9 -> 3
+                in 10..12 -> 4
+                else -> null
+            }
+            if (quarterNumber != null) {
+                signalPayload[com.telemetrydeck.sdk.params.Calendar.QuarterOfYear.paramName] = "$quarterNumber"
+            }
+        }
+
+        return signalPayload
+    }
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -187,7 +187,7 @@ class TelemetryDeckTests {
             .build(null)
         sut.signal("type")
 
-        Assert.assertEquals(4 + 1, sut.providers.count()) // default ones + the one added in the test
+        Assert.assertEquals(5 + 1, sut.providers.count()) // default ones + the one added in the test
         Assert.assertTrue(sut.providers.last() is TestTelemetryDeckProvider)
     }
 


### PR DESCRIPTION
This PR addresses https://github.com/TelemetryDeck/PirateMetrics/issues/43 by adding the following default parameters for all outgoing signals:


- `TelemetryDeck.Calendar.dayOfMonth`: The day-of-month (1..31) component of the date.
- `TelemetryDeck.Calendar.dayOfWeek`: The ISO 8601 number of the given day of the week. Monday is 1, Sunday is 7.
- `TelemetryDeck.Calendar.dayOfYear`: The 1-based day-of-year component of the date.
- `TelemetryDeck.Calendar.weekOfYear`: The week number within the current year as defined by `getFirstDayOfWeek()` and `getMinimalDaysInFirstWeek()`.
- `TelemetryDeck.Calendar.isWeekend`: `true` if the day of the week is Saturday or Sunday, `false` otherwise.
- `TelemetryDeck.Calendar.monthOfYear`: The number-of-the-month (1..12) component of the date.
- `TelemetryDeck.Calendar.quarterOfYear`: The the quarter-of-year (1..4). For API 26 and earlier, it's the number of the month divided by 3.
- `TelemetryDeck.Calendar.hourOfDay`: The hour-of-day (0..23) time component of this time value.
