### PR TITLE
Allow setting namespace via the builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ The Kotlin SDK for TelemetryDeck is available from Maven Central at the followin
 ```groovy
 // `build.gradle`
 dependencies {
-    implementation 'com.telemetrydeck:kotlin-sdk:6.0.0'
+    implementation 'com.telemetrydeck:kotlin-sdk:6.0.1'
 }
 ```
 
 ```kotlin
 // `build.gradle.kts`
 dependencies {
-    implementation("com.telemetrydeck:kotlin-sdk:6.0.0")
+    implementation("com.telemetrydeck:kotlin-sdk:6.0.1")
 }
 ```
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -107,7 +107,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.telemetrydeck", "kotlin-sdk", "6.0.0")
+    coordinates("com.telemetrydeck", "kotlin-sdk", "6.0.1")
 
     pom {
         name = "TelemetryDeck SDK"

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -462,7 +462,8 @@ class TelemetryDeck(
         private var identityProvider: TelemetryDeckIdentityProvider? = null,
         private var sessionProvider: TelemetryDeckSessionManagerProvider? = null,
         private var telemetryClientFactory: TelemetryApiClientFactory? = null,
-        private var signalCache: SignalCache? = null
+        private var signalCache: SignalCache? = null,
+        private var namespace: String? = null,
     ) {
         /**
          * Set the [TelemetryDeck] configuration.
@@ -552,6 +553,10 @@ class TelemetryDeck(
             this.logger = debugLogger
         }
 
+        fun namespace(namespace: String?) = apply {
+            this.namespace = namespace
+        }
+
         fun build(context: Context?): TelemetryDeck {
             var config = this.configuration
             val appID = this.appID
@@ -601,6 +606,10 @@ class TelemetryDeck(
             val showDebugLogs = this.showDebugLogs
             if (showDebugLogs != null) {
                 config.showDebugLogs = showDebugLogs
+            }
+            val namespace = this.namespace
+            if (!namespace.isNullOrBlank()) {
+                config.namespace = namespace
             }
 
             val logger: DebugLogger = this.logger ?: TelemetryManagerDebugLogger

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
@@ -29,7 +29,7 @@ class EnvironmentParameterProvider : TelemetryDeckProvider {
     private val platform: String = "Android"
     private val os: String = "Android"
     private val sdkName: String = "KotlinSDK"
-    private val sdkVersion: String = "6.0.0"
+    private val sdkVersion: String = "6.0.1"
 
     override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
         appendContextSpecificParams(ctx, client.debugLogger)

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -123,6 +123,16 @@ class TelemetryDeckTests {
     }
 
     @Test
+    fun telemetryDeck_builder_set_namespace() {
+        val sut = TelemetryDeck.Builder()
+        val result =
+            sut.appID("32CB6574-6732-4238-879F-582FEBEB6536")
+                .namespace("acme")
+                .build(null)
+        Assert.assertEquals("acme", result.configuration.namespace)
+    }
+
+    @Test
     fun telemetryDeck_builder_set_showDebugLogs() {
         val sut = TelemetryDeck.Builder()
         val result =


### PR DESCRIPTION
This PR allows for the namespace to be set using the builder, so it can be exposed in use-cases where the configuration is not provided directly (e.g. the [FlutterSDK](https://github.com/TelemetryDeck/FlutterSDK/pull/38))