### PR TITLE
Extend duration signals

### DIFF
--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/DurationSignalTrackerProviderTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/DurationSignalTrackerProviderTest.kt
@@ -39,7 +39,7 @@ class DurationSignalTrackerProviderTest {
     @Test
     fun tracks_a_signal_duration() {
         val sut = createSut()
-        sut.startTracking("signal1", emptyMap())
+        sut.startTracking("signal1", emptyMap(), false)
         // sleep for 5 seconds
         Thread.sleep(5000)
         val params = sut.stopTracking("signal1", emptyMap())
@@ -60,7 +60,7 @@ class DurationSignalTrackerProviderTest {
     @Test
     fun tracks_a_signal_duration_with_starting_and_endingparams() {
         val sut = createSut()
-        sut.startTracking("signal1", mapOf("param1" to "value1"))
+        sut.startTracking("signal1", mapOf("param1" to "value1"), false)
         // sleep for 5 seconds
         Thread.sleep(5000)
         val params = sut.stopTracking("signal1", mapOf("param2" to "value3"))
@@ -86,7 +86,7 @@ class DurationSignalTrackerProviderTest {
         val twoHoursAgo = Date(now.time - 7200000)
         val hourAgo = Date(now.time - 3600000)
         val state = DurationSignalTrackerProvider.TrackerState(
-            signals = mapOf("signal1" to DurationSignalTrackerProvider.CachedData(startTime = twoHoursAgo, parameters = mapOf("param1" to "value1"))),
+            signals = mapOf("signal1" to DurationSignalTrackerProvider.CachedData(startTime = twoHoursAgo, parameters = mapOf("param1" to "value1"), false)),
             lastEnteredBackground = hourAgo
         )
         prepareState(state)
@@ -114,13 +114,13 @@ class DurationSignalTrackerProviderTest {
         val twoHoursAgo = Date(now.time - 7200000)
         val hourAgo = Date(now.time - 3700000)
         val state = DurationSignalTrackerProvider.TrackerState(
-            signals = mapOf("signal1" to DurationSignalTrackerProvider.CachedData(startTime = twoHoursAgo, parameters = mapOf("param1" to "value1"))),
+            signals = mapOf("signal1" to DurationSignalTrackerProvider.CachedData(startTime = twoHoursAgo, parameters = mapOf("param1" to "value1"), false)),
             lastEnteredBackground = hourAgo
         )
         prepareState(state)
         val sut = createSut()
 
-        sut.handleOnStart()
+        sut.handleOnForeground()
         val params = sut.stopTracking("signal1", mapOf("param2" to "value3"))
 
         assertEquals("value1", params?.get("param1"))

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.test.annotation.UiThreadTest
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.telemetrydeck.sdk.providers.DurationSignalTrackerProvider
 import com.telemetrydeck.sdk.providers.SessionTrackingSignalProvider
 import com.telemetrydeck.sdk.signals.Acquisition
 import com.telemetrydeck.sdk.signals.Session
@@ -24,6 +25,8 @@ import java.io.File
 import java.net.URL
 import java.util.Date
 import java.util.UUID
+import kotlin.collections.find
+import kotlin.text.startsWith
 
 
 @RunWith(AndroidJUnit4::class)
@@ -334,9 +337,53 @@ class TelemetryDeckTest {
                     it.payload.find { it.startsWith("TelemetryDeck.Signal.durationInSeconds:") }
                 assertNotNull(duration)
                 assertEquals(10.0, it.floatValue)
-                assertEquals("04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb", it.clientUser)
+                assertEquals(
+                    "04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb",
+                    it.clientUser
+                )
             })
         }
+    }
+
+    @UiThreadTest
+    @Test
+    fun duration_tracking_with_and_without_background_time() {
+        startTelemetryDeck(
+            prepareBuilder()
+                .testMode(false)
+        )
+
+        val sut =
+            (TelemetryDeck.instance!!.providers.find { it is DurationSignalTrackerProvider } as DurationSignalTrackerProvider)
+
+        val now = Date()
+        sut.handleOnForeground(now)
+
+        sut.startTracking("foreground", emptyMap(), includeBackgroundTime = false, now)
+        sut.startTracking("foreground_and_background", emptyMap(), includeBackgroundTime = true, now)
+
+        // +600seconds, simulate going into the background 10 minutes later
+        val time1 = Date(now.time + 1000 * 10 * 60)
+        sut.handleOnBackground(
+            Date(now.time + 1000 * 10 * 60)
+        )
+
+        // +3600seconds, and back to foreground an hour later
+        val endTime = Date(time1.time + (1000 * 60 * 60))
+
+        sut.handleOnForeground(
+            endTime
+        )
+
+        val paramsForeground = sut.stopTracking("foreground", emptyMap(), endTime)
+        val paramsForeAndBackground =
+            sut.stopTracking("foreground_and_background", emptyMap(), endTime)
+
+        assertNotNull(paramsForeground)
+        assertNotNull(paramsForeAndBackground)
+
+        assertEquals("600.000", paramsForeground?.get("TelemetryDeck.Signal.durationInSeconds"))
+        assertEquals("4200.000", paramsForeAndBackground?.get("TelemetryDeck.Signal.durationInSeconds"))
     }
 
 

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
@@ -315,6 +315,30 @@ class TelemetryDeckTest {
         }
     }
 
+    @UiThreadTest
+    @Test
+    fun allows_for_duration_tracking_with_floatvalue_customer_id() {
+        val signalCache = startTelemetryDeck(
+            prepareBuilder()
+        )
+
+        // act
+        TelemetryDeck.startDurationSignal("type")
+        TelemetryDeck.stopAndSendDurationSignal("type", floatValue = 10.0, customUserID = "user")
+
+
+        verify {
+            signalCache.add(withArg {
+                assertEquals("type", it.type)
+                val duration =
+                    it.payload.find { it.startsWith("TelemetryDeck.Signal.durationInSeconds:") }
+                assertNotNull(duration)
+                assertEquals(10.0, it.floatValue)
+                assertEquals("04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb", it.clientUser)
+            })
+        }
+    }
+
 
     private fun prepareBuilder(): TelemetryDeck.Builder {
         val httpClient = mockk<TelemetryApiClient>()

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -155,13 +155,13 @@ class TelemetryDeck(
         )
     }
 
-    override fun startDurationSignal(signalName: String, parameters: Map<String, String>) {
+    override fun startDurationSignal(signalName: String, parameters: Map<String, String>, includeBackgroundTime: Boolean) {
         val trackingProvider = this.providers.find { it is DurationSignalTrackerProvider } as? DurationSignalTrackerProvider
         if (trackingProvider == null) {
             this.logger?.error("startDurationSignal requires the DurationSignalTrackerProvider to be registered")
             return
         }
-        trackingProvider.startTracking(signalName, parameters)
+        trackingProvider.startTracking(signalName, parameters, includeBackgroundTime)
     }
 
     override fun stopAndSendDurationSignal(signalName: String, parameters: Map<String, String>, floatValue: Double?, customUserID: String?) {
@@ -427,8 +427,8 @@ class TelemetryDeck(
             )
         }
 
-        override fun startDurationSignal(signalName: String, parameters: Map<String, String>) {
-            getInstance()?.startDurationSignal(signalName, parameters)
+        override fun startDurationSignal(signalName: String, parameters: Map<String, String>, includeBackgroundTime: Boolean) {
+            getInstance()?.startDurationSignal(signalName, parameters, includeBackgroundTime)
         }
 
         override fun stopAndSendDurationSignal(

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -164,7 +164,7 @@ class TelemetryDeck(
         trackingProvider.startTracking(signalName, parameters)
     }
 
-    override fun stopAndSendDurationSignal(signalName: String, parameters: Map<String, String>) {
+    override fun stopAndSendDurationSignal(signalName: String, parameters: Map<String, String>, floatValue: Double?, customUserID: String?) {
         val trackingProvider = this.providers.find { it is DurationSignalTrackerProvider } as? DurationSignalTrackerProvider
         if (trackingProvider == null) {
             this.logger?.error("stopAndSendDurationSignal requires the DurationSignalTrackerProvider to be registered")
@@ -172,7 +172,12 @@ class TelemetryDeck(
         }
         val params = trackingProvider.stopTracking(signalName, parameters)
         if (params != null) {
-            processSignal(signalName, params = params)
+            processSignal(
+                signalName,
+                params = params,
+                floatValue = floatValue,
+                customUserID = customUserID
+            )
         }
     }
 
@@ -428,9 +433,11 @@ class TelemetryDeck(
 
         override fun stopAndSendDurationSignal(
             signalName: String,
-            parameters: Map<String, String>
+            parameters: Map<String, String>,
+            floatValue: Double?,
+            customUserID: String?
         ) {
-            getInstance()?.stopAndSendDurationSignal(signalName, parameters)
+            getInstance()?.stopAndSendDurationSignal(signalName, parameters, floatValue, customUserID)
         }
 
         override val signalCache: SignalCache?

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -138,9 +138,11 @@ interface TelemetryDeckClient {
      *
      * @param signalName The name of the signal that was previously started with [startDurationSignal]
      * @param parameters Additional parameters to include with the signal. These will be merged with the parameters provided at the start.
+     * @param floatValue An optional floating-point number that can be used to provide numerical data about the signal.
+     * @param customUserID An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration.
      *
      */
-    fun stopAndSendDurationSignal(signalName: String, parameters: Map<String, String> = emptyMap())
+    fun stopAndSendDurationSignal(signalName: String, parameters: Map<String, String> = emptyMap(), floatValue: Double? = null, customUserID: String? = null)
 
     val configuration: TelemetryManagerConfiguration?
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -121,8 +121,13 @@ interface TelemetryDeckClient {
      *
      * @param signalName The name of the signal to track. This will be used to identify and stop the duration tracking later.
      * @param parameters A dictionary of additional string key-value pairs that will be included when the duration signal is eventually sent.
+     * @param includeBackgroundTime Indicates if the duration tracked will include the time spent in the background.
      */
-    fun startDurationSignal(signalName: String, parameters: Map<String, String> = emptyMap())
+    fun startDurationSignal(
+        signalName: String,
+        parameters: Map<String, String> = emptyMap(),
+        includeBackgroundTime: Boolean = false
+    )
 
     /** Stops tracking the duration of a signal and sends it with the total duration.
      *


### PR DESCRIPTION
This PR fixes #82 by adding the following features to duration signals:

- `stopAndSendDurationSignal` now allows for a `floatValue` to be provided
- `stopAndSendDurationSignal` now allows for a `customUserID` to be provided
- `startDurationSignal` now allows for `includeBackgroundTime` to be set to `true`, so that total signal duration will include background and foreground time