### PR TITLE
Mark methods as experimental

### DIFF
--- a/lib/src/main/java/com/telemetrydeck/sdk/ExperimentalFeature.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/ExperimentalFeature.kt
@@ -1,0 +1,9 @@
+package com.telemetrydeck.sdk
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This API is experimental and may change in the future."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class ExperimentalFeature

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -69,6 +69,7 @@ class TelemetryDeck(
         navigate(navigationStatus.getLastDestination(), destinationPath, customUserID)
     }
 
+    @ExperimentalFeature
     override fun acquiredUser(channel: String, params: Map<String, String>, customUserID: String?) {
         val signalParams = mergeMapsWithOverwrite(params, mapOf(
             Acquisition.Channel.paramName to channel
@@ -80,6 +81,7 @@ class TelemetryDeck(
         )
     }
 
+    @ExperimentalFeature
     override fun leadStarted(leadId: String, params: Map<String, String>, customUserID: String?) {
         val signalParams = mergeMapsWithOverwrite(params, mapOf(
             Acquisition.LeadId.paramName to leadId
@@ -91,6 +93,7 @@ class TelemetryDeck(
         )
     }
 
+    @ExperimentalFeature
     override fun leadConverted(leadId: String, params: Map<String, String>, customUserID: String?) {
         val signalParams = mergeMapsWithOverwrite(params, mapOf(
             Acquisition.LeadId.paramName to leadId
@@ -343,6 +346,7 @@ class TelemetryDeck(
             getInstance()?.navigate(destinationPath, customUserID = customUserID)
         }
 
+        @ExperimentalFeature
         override fun acquiredUser(
             channel: String,
             params: Map<String, String>,
@@ -351,6 +355,7 @@ class TelemetryDeck(
             getInstance()?.acquiredUser(channel, params, customUserID)
         }
 
+        @ExperimentalFeature
         override fun leadStarted(
             leadId: String,
             params: Map<String, String>,
@@ -359,6 +364,7 @@ class TelemetryDeck(
             getInstance()?.leadStarted(leadId, params, customUserID)
         }
 
+        @ExperimentalFeature
         override fun leadConverted(
             leadId: String,
             params: Map<String, String>,

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -36,18 +36,21 @@ interface TelemetryDeckClient {
     /**
      * Send a `TelemetryDeck.Acquisition.userAcquired` signal with the provided channel.
      */
+    @ExperimentalFeature
     fun acquiredUser(channel: String, params: Map<String, String> = emptyMap(), customUserID: String? = null)
 
 
     /**
      * Send a `TelemetryDeck.Acquisition.leadStarted` signal with the provided leadId.
      */
+    @ExperimentalFeature
     fun leadStarted(leadId: String, params: Map<String, String> = emptyMap(), customUserID: String? = null)
 
 
     /**
      * Send a `TelemetryDeck.Acquisition.leadConverted` signal with the provided leadId.
      */
+    @ExperimentalFeature
     fun leadConverted(leadId: String, params: Map<String, String> = emptyMap(), customUserID: String? = null)
 
 


### PR DESCRIPTION
Some acquisition methods were shipped as private in the SwiftSDK with the intention of being refined in the future. Based on comments in https://github.com/TelemetryDeck/SwiftSDK/pull/230 I had incorrectly assumed they were approved.

Since they've been already shipped and documented, this PR marks them as experimental, so users are aware they may change in a future version.