### PR TITLE
Purchases, Free Trials, and Trial Conversions: Faciliy methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ With information from the marketplace where the user made a purchase, you can in
 
 ```kotlin
 TelemetryDeck.purchaseCompleted(
+            event = PurchaseEvent.PAID_PURCHASE,
             countryCode = "BE",
             productID = "product1",
             purchaseType = PurchaseType.ONE_TIME_PURCHASE,
@@ -457,13 +458,19 @@ TelemetryDeck.purchaseCompleted(
         )
 ```
 
-This will result in a `TelemetryDeck.Purchase.completed` signal appearing on the dashboard with a `floatValue` set to the purchase amount, converted `USD`.
+Depending on the specified `PurchaseEvent`, one of the following signal will be sent:
+- `TelemetryDeck.Purchase.completed`
+- `TelemetryDeck.Purchase.freeTrialStarted`
+- `TelemetryDeck.Purchase.convertedFromTrial`
 
-The following parameters will be included with the signal:
+
+The `floatValue` of the signal will be set to the provided purchase amount, converted `USD`.
+
+The following parameters are also included with the signal:
 
 | Parameter                             | Description                                                                   |
 |---------------------------------------|-------------------------------------------------------------------------------|
-| `TelemetryDeck.Purchase.type`         | `ubscription` or `one-time-purchase`                                          |
+| `TelemetryDeck.Purchase.type`         | `subscription` or `one-time-purchase`                                         |
 | `TelemetryDeck.Purchase.countryCode`  | The country code of the marketplace where the purchase was made               |
 | `TelemetryDeck.Purchase.currencyCode` | The ISO 4217 currency code (e.g., "EUR" for Euro) used for the purchase.      |
 | `TelemetryDeck.Purchase.priceMicros`  | The price of the product in micro-units of the currency                       |

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ TelemetryDeck.purchaseCompleted(
         )
 ```
 
-Depending on the specified `PurchaseEvent`, one of the following signal will be sent:
+Depending on the specified `PurchaseEvent`, one of the following signals will be sent:
 - `TelemetryDeck.Purchase.completed`
 - `TelemetryDeck.Purchase.freeTrialStarted`
 - `TelemetryDeck.Purchase.convertedFromTrial`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Android applications. Sign up for a free account at [telemetrydeck.com](https://
 * [Acquisition](#acquisition)
 * [Session Tracking](#session-tracking)
 * [Custom Telemetry](#custom-telemetry)
+* [Purchase Completed](#purchase-completed)
 * [Custom Logging](#custom-logging)
 * [Requirements](#requirements)
 * [Migrating providers to 5.0+](#migrating-providers-to-50)
@@ -438,6 +439,37 @@ By default, the KotlinSDK will append the following parameters to all outgoing s
 - `TelemetryDeck.Calendar.monthOfYear`: The number-of-the-month (1..12) component of the date.
 - `TelemetryDeck.Calendar.quarterOfYear`: The the quarter-of-year (1..4). For API 26 and earlier, it's the number of the month divided by 3.
 - `TelemetryDeck.Calendar.hourOfDay`: The hour-of-day (0..23) time component of this time value.
+
+
+## Purchase Completed
+
+The SDK offers a facility method `TelemetryDeck.purchaseCompleted()` that can be invoked in response to a user purchase.
+With information from the marketplace where the user made a purchase, you can inform TelemetryDeck as follows:
+
+```kotlin
+TelemetryDeck.purchaseCompleted(
+            countryCode = "BE",
+            productID = "product1",
+            purchaseType = PurchaseType.ONE_TIME_PURCHASE,
+            priceAmountMicros = 7990000,
+            currencyCode = "EUR",
+            offerID = "offer1"
+        )
+```
+
+This will result in a `TelemetryDeck.Purchase.completed` signal appearing on the dashboard with a `floatValue` set to the purchase amount, converted `USD`.
+
+The following parameters will be included with the signal:
+
+| Parameter                             | Description                                                                   |
+|---------------------------------------|-------------------------------------------------------------------------------|
+| `TelemetryDeck.Purchase.type`         | `ubscription` or `one-time-purchase`                                          |
+| `TelemetryDeck.Purchase.countryCode`  | The country code of the marketplace where the purchase was made               |
+| `TelemetryDeck.Purchase.currencyCode` | The ISO 4217 currency code (e.g., "EUR" for Euro) used for the purchase.      |
+| `TelemetryDeck.Purchase.priceMicros`  | The price of the product in micro-units of the currency                       |
+| `TelemetryDeck.Purchase.productID`    | The unique identifier of the purchased product                                |
+| `TelemetryDeck.Purchase.offerID`      | The specific offer identifier for subscription products or customized pricing |
+
 
 ## Custom Telemetry
 

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
@@ -315,6 +315,38 @@ class TelemetryDeckTest {
         }
     }
 
+    @UiThreadTest
+    @Test
+    fun purchase_completed_converts_currency() {
+        val signalCache = startTelemetryDeck(
+            prepareBuilder()
+        )
+
+        // act
+        TelemetryDeck.purchaseCompleted(
+            countryCode = "BE",
+            productID = "product1",
+            purchaseType = PurchaseType.ONE_TIME_PURCHASE,
+            priceAmountMicros = 7990000,
+            currencyCode = "EUR",
+            offerID = "offer1"
+        )
+
+
+        verify {
+            signalCache.add(withArg {
+                assertEquals("TelemetryDeck.Purchase.completed", it.type)
+                assert(it.payload.any { it == "TelemetryDeck.Purchase.type:one-time-purchase" })
+                assert(it.payload.any { it == "TelemetryDeck.Purchase.countryCode:BE" })
+                assert(it.payload.any { it == "TelemetryDeck.Purchase.currencyCode:EUR" })
+                assert(it.payload.any { it == "TelemetryDeck.Purchase.productID:product1" })
+                assert(it.payload.any { it == "TelemetryDeck.Purchase.offerID:offer1" })
+                assert(it.payload.any { it == "TelemetryDeck.Purchase.priceMicros:7990000" })
+                assert(it.floatValue == 8.38)
+            })
+        }
+    }
+
 
     private fun prepareBuilder(): TelemetryDeck.Builder {
         val httpClient = mockk<TelemetryApiClient>()

--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
@@ -324,6 +324,7 @@ class TelemetryDeckTest {
 
         // act
         TelemetryDeck.purchaseCompleted(
+            event = PurchaseEvent.PAID_PURCHASE,
             countryCode = "BE",
             productID = "product1",
             purchaseType = PurchaseType.ONE_TIME_PURCHASE,

--- a/lib/src/main/java/com/telemetrydeck/sdk/CurrencyConverter.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/CurrencyConverter.kt
@@ -1,0 +1,207 @@
+package com.telemetrydeck.sdk
+
+import kotlin.math.roundToInt
+
+object CurrencyConverter {
+    private val currencyCodeToOneUSDExchangeRate = mapOf(
+        "AED" to 3.6725,
+        "AFN" to 73.1439,
+        "ALL" to 94.4244,
+        "AMD" to 396.6171,
+        "ANG" to 1.7900,
+        "AOA" to 915.1721,
+        "ARS" to 1058.5000,
+        "AUD" to 1.5742,
+        "AWG" to 1.7900,
+        "AZN" to 1.7002,
+        "BAM" to 1.8645,
+        "BBD" to 2.0000,
+        "BDT" to 121.5449,
+        "BGN" to 1.8646,
+        "BHD" to 0.3760,
+        "BIF" to 2964.2266,
+        "BMD" to 1.0000,
+        "BND" to 1.3398,
+        "BOB" to 6.9305,
+        "BRL" to 5.7132,
+        "BSD" to 1.0000,
+        "BTN" to 86.7994,
+        "BWP" to 13.8105,
+        "BYN" to 3.2699,
+        "BZD" to 2.0000,
+        "CAD" to 1.4182,
+        "CDF" to 2856.7620,
+        "CHF" to 0.8997,
+        "CLP" to 946.3948,
+        "CNY" to 7.2626,
+        "COP" to 4127.8455,
+        "CRC" to 507.0750,
+        "CUP" to 24.0000,
+        "CVE" to 105.1179,
+        "CZK" to 23.8700,
+        "DJF" to 177.7210,
+        "DKK" to 7.1119,
+        "DOP" to 62.0869,
+        "DZD" to 135.3706,
+        "EGP" to 50.6290,
+        "ERN" to 15.0000,
+        "ETB" to 126.2459,
+        "EUR" to 0.9533,
+        "FJD" to 2.2940,
+        "FKP" to 0.7948,
+        "FOK" to 7.1120,
+        "GBP" to 0.7948,
+        "GEL" to 2.8302,
+        "GGP" to 0.7948,
+        "GHS" to 15.4508,
+        "GIP" to 0.7948,
+        "GMD" to 72.6046,
+        "GNF" to 8589.0144,
+        "GTQ" to 7.7216,
+        "GYD" to 209.2593,
+        "HKD" to 7.7837,
+        "HNL" to 25.5206,
+        "HRK" to 7.1828,
+        "HTG" to 130.8347,
+        "HUF" to 383.5426,
+        "IDR" to 16225.1575,
+        "ILS" to 3.5481,
+        "IMP" to 0.7948,
+        "INR" to 86.7955,
+        "IQD" to 1307.9508,
+        "IRR" to 41993.2160,
+        "ISK" to 140.4283,
+        "JEP" to 0.7948,
+        "JMD" to 157.9457,
+        "JOD" to 0.7090,
+        "JPY" to 152.3479,
+        "KES" to 129.2574,
+        "KGS" to 87.4567,
+        "KHR" to 4008.1629,
+        "KID" to 1.5744,
+        "KMF" to 469.0028,
+        "KRW" to 1440.3458,
+        "KWD" to 0.3085,
+        "KYD" to 0.8333,
+        "KZT" to 497.5012,
+        "LAK" to 21867.2622,
+        "LBP" to 89500.0000,
+        "LKR" to 295.5196,
+        "LRD" to 199.3352,
+        "LSL" to 18.3599,
+        "LYD" to 4.9073,
+        "MAD" to 9.9608,
+        "MDL" to 18.8154,
+        "MGA" to 4734.8216,
+        "MKD" to 58.8122,
+        "MMK" to 2099.5486,
+        "MNT" to 3439.8970,
+        "MOP" to 8.0173,
+        "MRU" to 39.9597,
+        "MUR" to 46.4371,
+        "MVR" to 15.4548,
+        "MWK" to 1736.3946,
+        "MXN" to 20.3269,
+        "MYR" to 4.4350,
+        "MZN" to 63.6976,
+        "NAD" to 18.3599,
+        "NGN" to 1509.8070,
+        "NIO" to 36.7984,
+        "NOK" to 11.1191,
+        "NPR" to 138.8791,
+        "NZD" to 1.7453,
+        "OMR" to 0.3845,
+        "PAB" to 1.0000,
+        "PEN" to 3.7091,
+        "PGK" to 4.0165,
+        "PHP" to 57.7773,
+        "PKR" to 279.0304,
+        "PLN" to 3.9665,
+        "PYG" to 7905.2559,
+        "QAR" to 3.6400,
+        "RON" to 4.7473,
+        "RSD" to 111.7081,
+        "RUB" to 91.0874,
+        "RWF" to 1405.5288,
+        "SAR" to 3.7500,
+        "SBD" to 8.6689,
+        "SCR" to 14.4355,
+        "SDG" to 459.0793,
+        "SEK" to 10.6997,
+        "SGD" to 1.3398,
+        "SHP" to 0.7948,
+        "SLE" to 22.8772,
+        "SLL" to 22877.1788,
+        "SOS" to 571.5471,
+        "SRD" to 35.4328,
+        "SSP" to 4391.5735,
+        "STN" to 23.3563,
+        "SYP" to 12933.0491,
+        "SZL" to 18.3599,
+        "THB" to 33.6413,
+        "TJS" to 10.9222,
+        "TMT" to 3.5008,
+        "TND" to 3.1727,
+        "TOP" to 2.3859,
+        "TRY" to 36.2290,
+        "TTD" to 6.7863,
+        "TVD" to 1.5744,
+        "TWD" to 32.6576,
+        "TZS" to 2592.2504,
+        "UAH" to 41.5989,
+        "UGX" to 3674.9872,
+        "UYU" to 43.2704,
+        "UZS" to 12992.6998,
+        "VES" to 62.0708,
+        "VND" to 25400.2138,
+        "VUV" to 123.0591,
+        "WST" to 2.8244,
+        "XAF" to 625.3371,
+        "XCD" to 2.7000,
+        "XDR" to 0.7614,
+        "XOF" to 625.3371,
+        "XPF" to 113.7616,
+        "YER" to 247.9730,
+        "ZAR" to 18.3601,
+        "ZMW" to 28.1645,
+        "ZWL" to 26.4365
+    )
+
+    /**
+     * Converts a price amount in micros from a given currency to USD
+     *
+     * @param priceAmountMicros The price amount in micros (millionths) in the original currency
+     * @param currencyCode The currency code to convert from (e.g., "EUR", "GBP")
+     * @return The amount converted to USD, or 0 if the currency code is invalid
+     */
+    fun convertToUSD(priceAmountMicros: Long, currencyCode: String?): Double {
+        val amount = priceAmountMicros / 1_000_000.0
+        val convertedAmount = convertToUSD(amount, currencyCode)
+        // rounding to 100th to avoid floating point precision issues when dealing with "currency"
+        return (convertedAmount * 100).roundToInt() / 100.0
+    }
+
+
+
+    /**
+     * Converts an amount from a given currency to USD.
+     *
+     * @param amount The amount in the original currency
+     * @param currencyCode The currency code to convert from (e.g., "EUR", "GBP")
+     * @return The amount converted to USD, or 0 if the currency code is invalid or not found
+     */
+    fun convertToUSD(amount: Double, currencyCode: String?): Double {
+        return when (currencyCode) {
+            null -> 0.0
+            "USD" -> amount
+            else -> {
+                val exchangeRate = currencyCodeToOneUSDExchangeRate[currencyCode]
+                if (exchangeRate != null && exchangeRate != 0.0) {
+                    amount / exchangeRate
+                } else {
+                    0.0
+                }
+            }
+        }
+    }
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/PurchaseEvent.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/PurchaseEvent.kt
@@ -1,0 +1,7 @@
+package com.telemetrydeck.sdk
+
+enum class PurchaseEvent {
+    STARTED_FREE_TRIAL,
+    CONVERTED_FROM_TRIAL,
+    PAID_PURCHASE,
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/PurchaseType.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/PurchaseType.kt
@@ -1,0 +1,6 @@
+package com.telemetrydeck.sdk
+
+enum class PurchaseType {
+    SUBSCRIPTION,
+    ONE_TIME_PURCHASE
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -142,5 +142,66 @@ interface TelemetryDeckClient {
      */
     fun stopAndSendDurationSignal(signalName: String, parameters: Map<String, String> = emptyMap())
 
+
+    /**
+     * Logs the completion of a purchase event.
+     *
+     * Once a purchase is completed, you can obtain purchase detail information from the billing library:
+     *
+     * ```kotlin
+     * // For one-time purchases (ProductDetails from Billing Library 5.0+), [PurchaseType.ONE_TIME_PURCHASE]
+     * fun getPurchaseDetails(productDetails: ProductDetails) {
+     *     // Get one-time purchase offering
+     *     val oneTimePurchaseOfferDetails = productDetails.oneTimePurchaseOfferDetails
+     *     oneTimePurchaseOfferDetails?.let {
+     *         val formattedPrice = it.formattedPrice // e.g., "$1.99"
+     *         val priceAmountMicros = it.priceAmountMicros // e.g., 1990000 (for $1.99)
+     *         val currencyCode = it.priceCurrencyCode // e.g., "USD"
+     *     }
+     * }
+     *
+     * // For subscriptions, [PurchaseType.SUBSCRIPTION]
+     * fun getSubscriptionDetails(productDetails: ProductDetails) {
+     *     // Get all subscription offers
+     *     val subscriptionOfferDetails = productDetails.subscriptionOfferDetails
+     *     subscriptionOfferDetails?.forEach { offerDetails ->
+     *         // Each offer might have multiple pricing phases
+     *         offerDetails.pricingPhases.pricingPhaseList.forEach { pricingPhase ->
+     *             val priceAmountMicros = pricingPhase.priceAmountMicros
+     *             val currencyCode = pricingPhase.priceCurrencyCode
+     *         }
+     *     }
+     * }
+     *
+     * // Obtaining the Google Play Country code
+     * val getBillingConfigParams = GetBillingConfigParams.newBuilder().build()
+     * billingClient.getBillingConfigAsync(getBillingConfigParams,
+     *     object : BillingConfigResponseListener {
+     *         override fun onBillingConfigResponse(
+     *             billingResult: BillingResult,
+     *             billingConfig: BillingConfig?
+     *         ) {
+     *             if (billingResult.responseCode == BillingResponseCode.OK
+     *                 && billingConfig != null) {
+     *                 val countryCode = billingConfig.countryCode
+     *                 ...
+     *             }
+     *         }
+     *     })
+     *
+     * ```
+     *
+     *
+     * @param countryCode The country code format is based on ISO-3166-1 alpha2 (UN country codes). https://unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html
+     * @param productID The unique identifier of the purchased product.
+     * @param purchaseType The type of purchase, either a subscription or a one-time purchase.
+     * @param priceAmountMicros The price of the product in micro-units of the currency (e.g., 1,000,000 micro-units equal 1 unit of the currency).
+     * @param currencyCode The ISO 4217 currency code (e.g., "EUR" for Euro) used for the purchase.
+     * @param offerID: The specific offer identifier for subscription products.
+     * @param params A map of additional string key-value pairs that provide further context about the signal.
+     * @param customUserID An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration.
+     */
+    fun purchaseCompleted(countryCode: String, productID: String, purchaseType: PurchaseType, priceAmountMicros: Long, currencyCode: String, offerID: String? = null, params: Map<String, String> = emptyMap(), customUserID: String? = null)
+
     val configuration: TelemetryManagerConfiguration?
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -146,6 +146,20 @@ interface TelemetryDeckClient {
     /**
      * Logs the completion of a purchase event.
      *
+     *
+     * @param event A `PurchaseEvent` instance representing the type of purchase action being tracked. Instances can include purchase completion, free trial start, or conversion from trial.
+     * @param countryCode The country code format is based on ISO-3166-1 alpha2 (UN country codes). https://unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html
+     * @param productID The unique identifier of the purchased product.
+     * @param purchaseType The type of purchase, either a subscription or a one-time purchase.
+     * @param priceAmountMicros The price of the product in micro-units of the currency (e.g., 1,000,000 micro-units equal 1 unit of the currency).
+     * @param currencyCode The ISO 4217 currency code (e.g., "EUR" for Euro) used for the purchase.
+     * @param offerID: The specific offer identifier for subscription products.
+     * @param params A map of additional string key-value pairs that provide further context about the signal.
+     * @param customUserID An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration.
+     *
+     *
+     *
+     *
      * Once a purchase is completed, you can obtain purchase detail information from the billing library:
      *
      * ```kotlin
@@ -190,18 +204,8 @@ interface TelemetryDeckClient {
      *     })
      *
      * ```
-     *
-     *
-     * @param countryCode The country code format is based on ISO-3166-1 alpha2 (UN country codes). https://unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html
-     * @param productID The unique identifier of the purchased product.
-     * @param purchaseType The type of purchase, either a subscription or a one-time purchase.
-     * @param priceAmountMicros The price of the product in micro-units of the currency (e.g., 1,000,000 micro-units equal 1 unit of the currency).
-     * @param currencyCode The ISO 4217 currency code (e.g., "EUR" for Euro) used for the purchase.
-     * @param offerID: The specific offer identifier for subscription products.
-     * @param params A map of additional string key-value pairs that provide further context about the signal.
-     * @param customUserID An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration.
      */
-    fun purchaseCompleted(countryCode: String, productID: String, purchaseType: PurchaseType, priceAmountMicros: Long, currencyCode: String, offerID: String? = null, params: Map<String, String> = emptyMap(), customUserID: String? = null)
+    fun purchaseCompleted(event: PurchaseEvent, countryCode: String, productID: String, purchaseType: PurchaseType, priceAmountMicros: Long, currencyCode: String, offerID: String? = null, params: Map<String, String> = emptyMap(), customUserID: String? = null)
 
     val configuration: TelemetryManagerConfiguration?
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Purchase.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Purchase.kt
@@ -1,0 +1,10 @@
+package com.telemetrydeck.sdk.params
+
+internal enum class Purchase(val paramName: String) {
+    Type("TelemetryDeck.Purchase.type"),
+    CountryCode("TelemetryDeck.Purchase.countryCode"),
+    CurrencyCode("TelemetryDeck.Purchase.currencyCode"),
+    ProductID("TelemetryDeck.Purchase.productID"),
+    OfferID("TelemetryDeck.Purchase.offerID"),
+    PriceMicros("TelemetryDeck.Purchase.priceMicros"),
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/signals/Purchase.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/signals/Purchase.kt
@@ -1,0 +1,7 @@
+package com.telemetrydeck.sdk.signals
+
+internal enum class Purchase(val signalName: String) {
+    Completed("TelemetryDeck.Purchase.completed"),
+    FreeTrialStarted("TelemetryDeck.Purchase.freeTrialStarted"),
+    ConvertedFromTrial("TelemetryDeck.Purchase.convertedFromTrial"),
+}


### PR DESCRIPTION
Hi all, this PR addresses https://github.com/TelemetryDeck/PirateMetrics/issues/46 by adding a facility for reporting purchases. Since there is no billing library integration at this stage, all required information is provided by the user.

The method `TelemetryDeck.purchaseCompleted()` has been added and can be invoked in response to a user purchase.
With information from the marketplace where the user made a purchase, you can inform TelemetryDeck as follows:

```kotlin
TelemetryDeck.purchaseCompleted(
            event = PurchaseEvent.PAID_PURCHASE,
            countryCode = "BE",
            productID = "product1",
            purchaseType = PurchaseType.ONE_TIME_PURCHASE,
            priceAmountMicros = 7990000,
            currencyCode = "EUR",
            offerID = "offer1"
        )
```

Depending on the specified `PurchaseEvent`, one of the following signals will be sent:
- `TelemetryDeck.Purchase.completed`
- `TelemetryDeck.Purchase.freeTrialStarted`
- `TelemetryDeck.Purchase.convertedFromTrial`


The `floatValue` of the signal will be set to the provided purchase amount, converted `USD`.

The following parameters are also included with the signal:

| Parameter                             | Description                                                                   |
|---------------------------------------|-------------------------------------------------------------------------------|
| `TelemetryDeck.Purchase.type`         | `subscription` or `one-time-purchase`                                         |
| `TelemetryDeck.Purchase.countryCode`  | The country code of the marketplace where the purchase was made               |
| `TelemetryDeck.Purchase.currencyCode` | The ISO 4217 currency code (e.g., "EUR" for Euro) used for the purchase.      |
| `TelemetryDeck.Purchase.priceMicros`  | The price of the product in micro-units of the currency                       |
| `TelemetryDeck.Purchase.productID`    | The unique identifier of the purchased product                                |
| `TelemetryDeck.Purchase.offerID`      | The specific offer identifier for subscription products or customized pricing |
