### PR TITLE
Purchases, Free Trials, and Trial Conversions: Google Play Billing Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,51 @@ The following parameters are also included with the signal:
 | `TelemetryDeck.Purchase.offerID`      | The specific offer identifier for subscription products or customized pricing |
 
 
+### Google Play
+
+When integrating with Google Play Billing Library, you can adopt the TelemetryDeck SDK with Google Play Services in order to let us determine the exact purchase parameters.
+
+1. Add the following package as a dependency to your app:
+
+```kotlin
+// `build.gradle.kts`
+dependencies {
+    implementation("com.telemetrydeck:kotlin-sdk-google-services:6.2.0")
+}
+```
+
+2. You can now use the `purchaseCompleted` function optimized for Google Play Billing:
+
+```kotlin
+fun purchaseHandlerInYourApp(
+  billingConfig: BillingConfig,
+  purchase: Purchase,
+  productDetails: ProductDetails
+) {
+  TelemetryDeck.purchaseCompleted(
+    billingConfig = billingConfig,
+    purchase = purchase,
+    productDetails = productDetails
+  )
+}
+```
+
+By default, this method assumes the purchase is a `PAID_PURCHASE`. To determine if the user is converting or starting a trial, you will have to implement your own [server-side validation](https://developer.android.com/google/play/billing/integrate) and inspect the `paymentState` of a subscription.
+
+To make it easier to get started, the TelemetryDeck SDK offers a helper method which attempts to guess the purchase origin based on locally available data, so you could:
+
+```kotlin
+TelemetryDeck.purchaseCompleted(
+  billingConfig = billingConfig,
+  purchase = purchase,
+  productDetails = productDetails,
+  purchaseOrigin = purchase.toTelemetryDeckPurchaseEvent(setOf("TRIAL_SKU"))
+)
+```
+
+Note that this approach is not exact and comes with a certain number of limitations, please check the doc notes on `com.telemetrydeck.sdk.googleservices.toTelemetryDeckPurchaseEvent` for more details.
+
+
 ## Custom Telemetry
 
 Another way to send signals is to implement a custom `TelemetryDeckProvider`.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The Kotlin SDK for TelemetryDeck is available from Maven Central at the followin
 ```groovy
 // `build.gradle`
 dependencies {
-    implementation 'com.telemetrydeck:kotlin-sdk:6.1.0'
+    implementation 'com.telemetrydeck:kotlin-sdk:6.2.0'
 }
 ```
 
 ```kotlin
 // `build.gradle.kts`
 dependencies {
-    implementation("com.telemetrydeck:kotlin-sdk:6.1.0")
+    implementation("com.telemetrydeck:kotlin-sdk:6.2.0")
 }
 ```
 

--- a/google-services/build.gradle.kts
+++ b/google-services/build.gradle.kts
@@ -1,0 +1,103 @@
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import com.vanniktech.maven.publish.SonatypeHost
+
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.vanniktech.publish)
+}
+
+android {
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 21
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    lint {
+        targetSdk = 34
+    }
+
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        targetSdk = 34
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    buildFeatures {
+        compose = false
+        buildConfig = true
+    }
+
+    //    https://github.com/Kotlin/kotlinx.coroutines/blob/master/README.md#avoiding-including-the-debug-infrastructure-in-the-resulting-apk
+    packaging {
+        resources.excludes += "DebugProbesKt.bin"
+        resources.merges.addAll(
+            listOf(
+                "META-INF/LICENSE.md",
+                "META-INF/LICENSE-notice.md",
+            )
+        )
+    }
+    namespace = "com.telemetrydeck.sdk"
+}
+
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+dependencies {
+    implementation(libs.google.play.billing)
+    implementation(project(":lib"))
+
+}
+
+mavenPublishing {
+    coordinates("com.telemetrydeck", "kotlin-sdk-google-services", "6.1.0")
+
+    pom {
+        name = "TelemetryDeck SDK Google Services"
+        description =
+            "Google Services facilities for Kotlin SDK for TelemetryDeck, a privacy-conscious analytics service for apps and websites"
+        url = "https://telemetrydeck.com"
+
+        licenses {
+            license {
+                name = "MIT License"
+                url = "https://raw.githubusercontent.com/TelemetryDeck/KotlinSDK/main/LICENSE"
+            }
+        }
+
+        developers {
+            developer {
+                id = "winsmith"
+                name = "Daniel Jilg"
+                url = "https://github.com/winsmith"
+                organization = "TelemetryDeck GmbH"
+            }
+        }
+
+        scm {
+            url = "https://github.com/TelemetryDeck/KotlinSDK"
+        }
+    }
+}

--- a/google-services/build.gradle.kts
+++ b/google-services/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.telemetrydeck", "kotlin-sdk-google-services", "6.1.0")
+    coordinates("com.telemetrydeck", "kotlin-sdk-google-services", "6.2.0")
 
     pom {
         name = "TelemetryDeck SDK Google Services"

--- a/google-services/src/main/kotlin/com/telemetrydeck/sdk/googleservices/TelemetryDeck.kt
+++ b/google-services/src/main/kotlin/com/telemetrydeck/sdk/googleservices/TelemetryDeck.kt
@@ -1,0 +1,115 @@
+package com.telemetrydeck.sdk.googleservices
+
+import com.android.billingclient.api.BillingConfig
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import com.telemetrydeck.sdk.PurchaseEvent
+import com.telemetrydeck.sdk.PurchaseType
+import com.telemetrydeck.sdk.TelemetryDeck
+
+
+fun TelemetryDeck.purchaseCompleted(
+    billingConfig: BillingConfig,
+    purchase: Purchase,
+    productDetails: ProductDetails,
+    purchaseOrigin: PurchaseEvent,
+    params: Map<String, String>,
+    customUserID: String?
+) {
+    val productId = purchase.products.firstOrNull() ?: ""
+    val countryCode = billingConfig.countryCode
+
+    val isSubscription = productDetails.subscriptionOfferDetails != null
+    val purchaseType = if (isSubscription) PurchaseType.SUBSCRIPTION else PurchaseType.ONE_TIME_PURCHASE
+    val oneTimeOffer = productDetails.oneTimePurchaseOfferDetails
+
+    when (purchaseType) {
+        PurchaseType.SUBSCRIPTION -> {
+            // subscription
+            val pricePhase = productDetails.subscriptionOfferDetails
+                ?.firstOrNull()
+                ?.pricingPhases
+                ?.pricingPhaseList
+                ?.firstOrNull()
+            val priceAmountMicros = pricePhase?.priceAmountMicros ?: 0L
+            val currencyCode = pricePhase?.priceCurrencyCode ?: "USD"
+            val offerId = productDetails.subscriptionOfferDetails
+                ?.firstOrNull()
+                ?.offerId
+            TelemetryDeck.purchaseCompleted(
+                event = purchaseOrigin,
+                countryCode = countryCode,
+                productID = productId,
+                purchaseType = purchaseType,
+                priceAmountMicros = priceAmountMicros,
+                currencyCode = currencyCode,
+                offerID = offerId,
+                params = params,
+                customUserID = customUserID
+            )
+        }
+        PurchaseType.ONE_TIME_PURCHASE -> {
+            // one time purchase
+            val priceAmountMicros = oneTimeOffer?.priceAmountMicros ?: 0L
+            val currencyCode = oneTimeOffer?.priceCurrencyCode ?: "USD"
+            TelemetryDeck.purchaseCompleted(
+                event = purchaseOrigin,
+                countryCode = countryCode,
+                productID = productId,
+                purchaseType = purchaseType,
+                priceAmountMicros = priceAmountMicros,
+                currencyCode = currencyCode,
+                params = params,
+                customUserID = customUserID
+            )
+        }
+    }
+}
+
+/**
+ * Converts a `Purchase` object into a corresponding `PurchaseEvent` based on the purchase's SKU
+ * and its trial or paid purchase status.
+ *
+ * This method attempts to guess if a purchase corresponds to a trial conversion by checking the locally available information.
+ * We check if:
+ * 1) If the product was part of a known trial SKU and
+ * 2) If the purchase was recent (within the default trial window).
+ *
+ *
+ * - This does not detect free trials used on another device/account.
+ * - You must manually maintain the list of trial SKUs or base plans locally.
+ * - Does not work for Play offers that use multiple offer tokens under the same product ID.
+ *
+ *
+ * * It is best to implement server-side validation in order to query the Google Play API and inspect the paymentState.
+ *
+ * @param knownTrialSkus a set of SKUs that are recognized as free trial SKUs. List of product IDs (or SKUs) that you know include free trials. This should be manually maintained based on how you set up offers in the Play Console.
+ * @param trialWindowMs the duration (in milliseconds) considered as the trial period, defaulting to 7 days.
+ * @return a `PurchaseEvent` indicating the type of purchase: either a free trial start, trial conversion, or a standard paid purchase.
+ */
+fun Purchase.toTelemetryDeckPurchaseEvent(
+    knownTrialSkus: Set<String>,
+    trialWindowMs: Long = 7 * 24 * 60 * 60 * 1000L // 7 days
+): PurchaseEvent {
+    val sku = products.firstOrNull() ?: return PurchaseEvent.PAID_PURCHASE
+
+    return when {
+        // If SKU is one of our known free trial SKUs and the purchase is recent
+        sku in knownTrialSkus && isWithinTrialWindow(purchaseTime, trialWindowMs) -> {
+            PurchaseEvent.STARTED_FREE_TRIAL
+        }
+
+        // If SKU is a known trial SKU but purchase is outside trial window
+        sku in knownTrialSkus && !isWithinTrialWindow(purchaseTime, trialWindowMs) -> {
+            PurchaseEvent.CONVERTED_FROM_TRIAL
+        }
+
+        // Otherwise it's a standard paid purchase
+        else -> PurchaseEvent.PAID_PURCHASE
+    }
+}
+
+private fun isWithinTrialWindow(purchaseTimeMillis: Long, trialWindowMs: Long): Boolean {
+    val currentTime = System.currentTimeMillis()
+    return currentTime - purchaseTimeMillis <= trialWindowMs
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ mockk = "1.13.13"
 robolectric = "4.7.3"
 androidxTest = "1.6.1"
 datetime = "0.6.2"
+google-play-billing = "7.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -49,6 +50,7 @@ mockk = {group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-agent = {group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
 mockk-android = {group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 androidx-jUnitTestRules = { module = "androidx.test:rules", version.ref = "androidxTest" }
+google-play-billing = { module = "com.android.billingclient:billing", version.ref = "google-play-billing"}
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -107,7 +107,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.telemetrydeck", "kotlin-sdk", "6.1.0")
+    coordinates("com.telemetrydeck", "kotlin-sdk", "6.2.0")
 
     pom {
         name = "TelemetryDeck SDK"

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -369,7 +369,13 @@ class TelemetryDeck(
             }
         }
 
-        private fun getInstance(): TelemetryDeck? {
+        /**
+         * Retrieves the current instance of the `TelemetryDeck` singleton if available.
+         * If no instance exists, this method returns `null`.
+         *
+         * @return The current `TelemetryDeck` instance, or `null` if no instance is available.
+         */
+        fun getInstance(): TelemetryDeck? {
             val knownInstance = instance
             if (knownInstance != null) {
                 return knownInstance

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -154,7 +154,7 @@ interface TelemetryDeckClient {
 
 
     /**
-     * Logs the completion of a purchase event.
+     * Tracks the completion of a purchase event.
      *
      *
      * @param event A `PurchaseEvent` instance representing the type of purchase action being tracked. Instances can include purchase completion, free trial start, or conversion from trial.
@@ -170,7 +170,7 @@ interface TelemetryDeckClient {
      *
      *
      *
-     * Once a purchase is completed, you can obtain purchase detail information from the billing library:
+     * Once a purchase is completed, you can obtain purchase detail information from the Google Play Billing library:
      *
      * ```kotlin
      * // For one-time purchases (ProductDetails from Billing Library 5.0+), [PurchaseType.ONE_TIME_PURCHASE]

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
@@ -29,7 +29,7 @@ class EnvironmentParameterProvider : TelemetryDeckProvider {
     private val platform: String = "Android"
     private val os: String = "Android"
     private val sdkName: String = "KotlinSDK"
-    private val sdkVersion: String = "6.1.0"
+    private val sdkVersion: String = "6.2.0"
 
     override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
         appendContextSpecificParams(ctx, client.debugLogger)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "TelemetryDeck SDK"
 include(":lib")
+include(":google-services")


### PR DESCRIPTION
This PR addresses https://github.com/TelemetryDeck/PirateMetrics/issues/46 by adding integration with Google Play Billing to make it easier to signal the completion of a purchase based on data usually available upon completion of a purchase.

App can adopt the TelemetryDeck SDK with Google Play Services to let us determine the exact purchase parameters:

```kotlin
// `build.gradle.kts`
dependencies {
   // ... other dependencies
    implementation("com.telemetrydeck:kotlin-sdk-google-services:6.2.0")
}
```

ℹ️ The new package `com.telemetrydeck:kotlin-sdk-google-services` uses the same version as our base SDK dependency `com.telemetrydeck:kotlin-sdk`.

An overload of `purchaseCompleted` is now available:

```kotlin
import com.telemetrydeck.sdk.googleservices.purchaseCompleted

// ...

// function defined in an app, handling the completion of a purchase
fun purchaseHandlerInYourApp(
  billingConfig: BillingConfig,
  purchase: Purchase,
  productDetails: ProductDetails
) {
// calls the TelemetryDeck SDK:
  TelemetryDeck.purchaseCompleted(
    billingConfig = billingConfig,
    purchase = purchase,
    productDetails = productDetails
  )
}
```

⚠️ By default, this method assumes the purchase is a `PAID_PURCHASE`. To determine if the user is converting or starting a trial, one has to implement [server-side validation](https://developer.android.com/google/play/billing/integrate) and inspect the `paymentState` of a subscription.

To make it easier to get started, the TelemetryDeck SDK offers a helper method which attempts to guess the purchase origin based on locally available data:

```kotlin
import com.telemetrydeck.sdk.googleservices.toTelemetryDeckPurchaseEvent

// ...

TelemetryDeck.purchaseCompleted(
  billingConfig = billingConfig,
  purchase = purchase,
  productDetails = productDetails,
  purchaseOrigin = purchase.toTelemetryDeckPurchaseEvent(setOf("TRIAL_SKU"))
)
```

This method attempts to guess if a purchase corresponds to a trial conversion by checking the locally available information:

- If the product was part of a known trial SKU and
- If the purchase was recent (within the default trial window).

Notes:
- This does not detect free trials used on another device/account.
- You must manually maintain the list of trial SKUs or base plans locally.
- Does not work for Play offers that use multiple offer tokens under the same product ID.

The app needs to provide the following parameters:

- **knownTrialSkus** a set of SKUs that are recognized as free trial SKUs. List of product IDs (or SKUs) that you know include free trials. This should be manually maintained based on how you set up offers in the Play Console.
- **trialWindowMs** the duration (in milliseconds) considered as the trial period, defaulting to 7 days.