### PR TITLE
fix: payload now serialized as an object for Ingest v2

### DIFF
--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/TelemetryDeckTest.kt
@@ -258,12 +258,12 @@ class TelemetryDeckTest {
             signalCache.add(withArg {
                 assertEquals("type", it.type)
                 assertNotEquals(sessionID.toString(), it.sessionID)
-                assertNotNull(it.payload.find { it.startsWith("TelemetryDeck.Acquisition.firstSessionDate:") })
-                assertNotNull(it.payload.find { it.startsWith("TelemetryDeck.Retention.averageSessionSeconds:") })
-                assertNotNull(it.payload.find { it.startsWith("TelemetryDeck.Retention.distinctDaysUsed:") })
-                assertNotNull(it.payload.find { it.startsWith("TelemetryDeck.Retention.totalSessionsCount:") })
-                assertNotNull(it.payload.find { it.startsWith("TelemetryDeck.Retention.previousSessionSeconds:") })
-                assertNotNull(it.payload.find { it.startsWith("TelemetryDeck.Retention.distinctDaysUsedLastMonth:") })
+                assertNotNull(it.payload["TelemetryDeck.Acquisition.firstSessionDate"])
+                assertNotNull(it.payload["TelemetryDeck.Retention.averageSessionSeconds"])
+                assertNotNull(it.payload["TelemetryDeck.Retention.distinctDaysUsed"])
+                assertNotNull(it.payload["TelemetryDeck.Retention.totalSessionsCount"])
+                assertNotNull(it.payload["TelemetryDeck.Retention.previousSessionSeconds"])
+                assertNotNull(it.payload["TelemetryDeck.Retention.distinctDaysUsedLastMonth"])
             })
         }
     }
@@ -284,14 +284,14 @@ class TelemetryDeckTest {
         verify {
             signalCache.add(withArg { signal ->
                 assertEquals("type", signal.type)
-                assertNotNull(signal.payload.find { it.startsWith("TelemetryDeck.Calendar.dayOfMonth:") })
-                assertNotNull(signal.payload.find { it.startsWith("TelemetryDeck.Calendar.dayOfWeek:") })
-                assertNotNull(signal.payload.find { it.startsWith("TelemetryDeck.Calendar.dayOfYear:") })
-                assertNotNull(signal.payload.find { it.startsWith("TelemetryDeck.Calendar.weekOfYear:") })
-                assertNotNull(signal.payload.find { it.startsWith("TelemetryDeck.Calendar.isWeekend:") })
-                assertNotNull(signal.payload.find { it.startsWith("TelemetryDeck.Calendar.monthOfYear:") })
-                assertNotNull(signal.payload.find { it.startsWith("TelemetryDeck.Calendar.quarterOfYear:") })
-                assertNotNull(signal.payload.find { it.startsWith("TelemetryDeck.Calendar.hourOfDay:") })
+                assertNotNull(signal.payload["TelemetryDeck.Calendar.dayOfMonth"])
+                assertNotNull(signal.payload["TelemetryDeck.Calendar.dayOfWeek"])
+                assertNotNull(signal.payload["TelemetryDeck.Calendar.dayOfYear"])
+                assertNotNull(signal.payload["TelemetryDeck.Calendar.weekOfYear"])
+                assertNotNull(signal.payload["TelemetryDeck.Calendar.isWeekend"])
+                assertNotNull(signal.payload["TelemetryDeck.Calendar.monthOfYear"])
+                assertNotNull(signal.payload["TelemetryDeck.Calendar.quarterOfYear"])
+                assertNotNull(signal.payload["TelemetryDeck.Calendar.hourOfDay"])
             })
         }
     }
@@ -312,7 +312,7 @@ class TelemetryDeckTest {
             signalCache.add(withArg {
                 assertEquals("type", it.type)
                 val duration =
-                    it.payload.find { it.startsWith("TelemetryDeck.Signal.durationInSeconds:") }
+                    it.payload["TelemetryDeck.Signal.durationInSeconds"]
                 assertNotNull(duration)
             })
         }
@@ -334,7 +334,7 @@ class TelemetryDeckTest {
             signalCache.add(withArg {
                 assertEquals("type", it.type)
                 val duration =
-                    it.payload.find { it.startsWith("TelemetryDeck.Signal.durationInSeconds:") }
+                    it.payload["TelemetryDeck.Signal.durationInSeconds"]
                 assertNotNull(duration)
                 assertEquals(10.0, it.floatValue)
                 assertEquals(
@@ -408,12 +408,12 @@ class TelemetryDeckTest {
         verify {
             signalCache.add(withArg {
                 assertEquals("TelemetryDeck.Purchase.completed", it.type)
-                assert(it.payload.any { it == "TelemetryDeck.Purchase.type:one-time-purchase" })
-                assert(it.payload.any { it == "TelemetryDeck.Purchase.countryCode:BE" })
-                assert(it.payload.any { it == "TelemetryDeck.Purchase.currencyCode:EUR" })
-                assert(it.payload.any { it == "TelemetryDeck.Purchase.productID:product1" })
-                assert(it.payload.any { it == "TelemetryDeck.Purchase.offerID:offer1" })
-                assert(it.payload.any { it == "TelemetryDeck.Purchase.priceMicros:7990000" })
+                assert(it.payload["TelemetryDeck.Purchase.type"] == "one-time-purchase")
+                assert(it.payload["TelemetryDeck.Purchase.countryCode"] == "BE")
+                assert(it.payload["TelemetryDeck.Purchase.currencyCode"] == "EUR")
+                assert(it.payload["TelemetryDeck.Purchase.productID"] == "product1")
+                assert(it.payload["TelemetryDeck.Purchase.offerID"] == "offer1")
+                assert(it.payload["TelemetryDeck.Purchase.priceMicros"] == "7990000")
                 assert(it.floatValue == 8.38)
             })
         }

--- a/lib/src/main/java/com/telemetrydeck/sdk/Signal.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/Signal.kt
@@ -37,9 +37,9 @@ data class Signal(
 
 
     /**
-     * Tags in the form "key:value" to attach to the signal
+     * Tags in key-value pairs to attach to the signal
      */
-    var payload: List<String>,
+    var payload: Map<String, String>,
 
     /**
      * If "true", mark the signal as a testing signal and only show it in a dedicated test mode UI
@@ -55,6 +55,6 @@ data class Signal(
         appID = appID,
         type = signalType,
         clientUser = clientUser,
-        payload = payload.asMultiValueDimension
+        payload = payload.asMap
     )
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/SignalPayload.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/SignalPayload.kt
@@ -3,7 +3,6 @@ package com.telemetrydeck.sdk
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.properties.Properties
-import kotlinx.serialization.properties.encodeToMap
 import kotlinx.serialization.properties.encodeToStringMap
 
 @Serializable

--- a/lib/src/main/java/com/telemetrydeck/sdk/SignalPayload.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/SignalPayload.kt
@@ -3,6 +3,7 @@ package com.telemetrydeck.sdk
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.properties.Properties
+import kotlinx.serialization.properties.encodeToMap
 import kotlinx.serialization.properties.encodeToStringMap
 
 @Serializable
@@ -11,18 +12,12 @@ data class SignalPayload(
 ) {
 
     @OptIn(ExperimentalSerializationApi::class)
-    private val asMap: Map<String, Any> by lazy {
-        Properties.encodeToStringMap(this).filterKeys { !it.startsWith("additionalPayload") }
+    val asMap: Map<String, String> by lazy {
+        Properties.encodeToStringMap(this).filterKeys { !it.startsWith("additionalPayload") } + additionalPayload
     }
 
     val asMultiValueDimension: List<String> by lazy {
-        this.asMap.map { "${cleanKey(it.key)}:${it.value}" } + this.additionalPayload.map {
-            "${
-                cleanKey(
-                    it.key
-                )
-            }:${it.value}"
-        }
+        this.asMap.map { "${cleanKey(it.key)}:${it.value}" }
     }
 
     private fun cleanKey(key: String): String = key.replace(":", "_")

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -293,7 +293,7 @@ class TelemetryDeck(
             appID = configuration.telemetryAppID,
             type = signalTransform.signalType,
             clientUser = hashedUser,
-            payload = payload.asMultiValueDimension,
+            payload = payload.asMap,
             isTestMode = configuration.testMode.toString().lowercase(),
             floatValue = signalTransform.floatValue
         )

--- a/lib/src/test/java/com/telemetrydeck/sdk/SignalsUnitTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/SignalsUnitTest.kt
@@ -25,7 +25,7 @@ class SignalsUnitTest {
 
         assertEquals("type", signal.type)
         assertEquals("clientUser", signal.clientUser)
-        assertEquals("platform:Android", signal.payload[0])
+        assertEquals("Android", signal.payload["platform"])
     }
 
     @Test

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -200,7 +200,7 @@ class TelemetryDeckTests {
 
         Assert.assertNotNull(signal)
         Assert.assertEquals("TelemetryDeck.Acquisition.userAcquired", signal?.type)
-        Assert.assertEquals("TelemetryDeck.Acquisition.channel:channel 1", signal?.payload?.firstOrNull { it.startsWith("TelemetryDeck.Acquisition.channel:") })
+        Assert.assertEquals("channel 1", signal?.payload["TelemetryDeck.Acquisition.channel"])
     }
 
     @Test
@@ -215,7 +215,7 @@ class TelemetryDeckTests {
 
         Assert.assertNotNull(signal)
         Assert.assertEquals("TelemetryDeck.Acquisition.leadStarted", signal?.type)
-        Assert.assertEquals("TelemetryDeck.Acquisition.leadID:lead 1", signal?.payload?.firstOrNull { it.startsWith("TelemetryDeck.Acquisition.leadID:") })
+        Assert.assertEquals("lead 1", signal?.payload["TelemetryDeck.Acquisition.leadID"])
     }
 
     @Test
@@ -230,7 +230,7 @@ class TelemetryDeckTests {
 
         Assert.assertNotNull(signal)
         Assert.assertEquals("TelemetryDeck.Acquisition.leadConverted", signal?.type)
-        Assert.assertEquals("TelemetryDeck.Acquisition.leadID:lead 1", signal?.payload?.firstOrNull { it.startsWith("TelemetryDeck.Acquisition.leadID:") })
+        Assert.assertEquals("lead 1", signal?.payload["TelemetryDeck.Acquisition.leadID"])
     }
 
     @Test
@@ -277,20 +277,20 @@ class TelemetryDeckTests {
         // validate the navigation status payload
         // https://github.com/TelemetryDeck/KotlinSDK/issues/28
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.schemaVersion") },
-            "TelemetryDeck.Navigation.schemaVersion:1"
+            queuedSignal?.payload["TelemetryDeck.Navigation.schemaVersion"],
+            "1"
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.identifier") },
-            "TelemetryDeck.Navigation.identifier:source -> destination"
+            queuedSignal?.payload["TelemetryDeck.Navigation.identifier"],
+            "source -> destination"
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.sourcePath") },
-            "TelemetryDeck.Navigation.sourcePath:source"
+            queuedSignal?.payload["TelemetryDeck.Navigation.sourcePath"],
+            "source"
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.destinationPath") },
-            "TelemetryDeck.Navigation.destinationPath:destination"
+            queuedSignal?.payload["TelemetryDeck.Navigation.destinationPath"],
+            "destination"
         )
     }
 
@@ -349,20 +349,20 @@ class TelemetryDeckTests {
         // validate the navigation status payload
         // https://github.com/TelemetryDeck/KotlinSDK/issues/28
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.schemaVersion") },
-            "TelemetryDeck.Navigation.schemaVersion:1"
+            queuedSignal?.payload["TelemetryDeck.Navigation.schemaVersion"],
+            "1"
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.identifier") },
-            "TelemetryDeck.Navigation.identifier: -> destination"
+            queuedSignal?.payload["TelemetryDeck.Navigation.identifier"],
+            " -> destination"
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.sourcePath") },
-            "TelemetryDeck.Navigation.sourcePath:"
+            queuedSignal?.payload["TelemetryDeck.Navigation.sourcePath"],
+            ""
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.destinationPath") },
-            "TelemetryDeck.Navigation.destinationPath:destination"
+            queuedSignal?.payload["TelemetryDeck.Navigation.destinationPath"],
+            "destination"
         )
     }
 
@@ -384,20 +384,20 @@ class TelemetryDeckTests {
         // validate the navigation status payload
         // https://github.com/TelemetryDeck/KotlinSDK/issues/28
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.schemaVersion") },
-            "TelemetryDeck.Navigation.schemaVersion:1"
+            queuedSignal?.payload["TelemetryDeck.Navigation.schemaVersion"],
+            "1"
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.identifier") },
-            "TelemetryDeck.Navigation.identifier:destination1 -> destination2"
+            queuedSignal?.payload["TelemetryDeck.Navigation.identifier"],
+            "destination1 -> destination2"
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.sourcePath") },
-            "TelemetryDeck.Navigation.sourcePath:destination1"
+            queuedSignal?.payload["TelemetryDeck.Navigation.sourcePath"],
+            "destination1"
         )
         Assert.assertEquals(
-            queuedSignal?.payload?.single { it.startsWith("TelemetryDeck.Navigation.destinationPath") },
-            "TelemetryDeck.Navigation.destinationPath:destination2"
+            queuedSignal?.payload["TelemetryDeck.Navigation.destinationPath"],
+            "destination2"
         )
     }
 
@@ -446,7 +446,7 @@ class TelemetryDeckTests {
         // validate the signal type
         Assert.assertEquals(queuedSignal?.type, "test")
 
-        Assert.assertEquals("param1:value1", queuedSignal?.payload?.firstOrNull { it.startsWith("param1:") }, )
+        Assert.assertEquals("value1", queuedSignal?.payload["param1"])
     }
 
     @Test
@@ -463,7 +463,7 @@ class TelemetryDeckTests {
         // validate the signal type
         Assert.assertEquals("SignalPrefix.test", queuedSignal?.type)
         Assert.assertEquals(1.0, queuedSignal?.floatValue)
-        Assert.assertEquals("ParamPrefix.param1:value1", queuedSignal?.payload?.firstOrNull { it.startsWith("ParamPrefix.") }, )
+        Assert.assertEquals("value1", queuedSignal?.payload["ParamPrefix.param1"])
     }
 
     private fun hashString(input: String, algorithm: String = "SHA-256"): String {

--- a/lib/src/test/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProviderTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProviderTest.kt
@@ -24,8 +24,7 @@ class EnvironmentParameterProviderTest {
         Assert.assertNotNull(queuedSignal)
         Assert.assertEquals(
             true,
-            queuedSignal?.payload?.any { it.startsWith("TelemetryDeck.SDK.version:") }
-
+            queuedSignal?.payload["TelemetryDeck.SDK.version"]?.isNotEmpty()
         )
     }
 
@@ -42,7 +41,7 @@ class EnvironmentParameterProviderTest {
         Assert.assertNotNull(queuedSignal)
         Assert.assertEquals(
             true,
-            queuedSignal?.payload?.contains("telemetryClientVersion:my value")
+            queuedSignal?.payload["telemetryClientVersion"] == "my value"
         )
     }
 
@@ -59,7 +58,7 @@ class EnvironmentParameterProviderTest {
         Assert.assertNotNull(queuedSignal)
         Assert.assertEquals(
             true,
-            queuedSignal?.payload?.filter { it.startsWith("TelemetryDeck.SDK.buildType:") }?.isNotEmpty()
+            queuedSignal?.payload["TelemetryDeck.SDK.buildType"]?.isNotEmpty()
         )
     }
 }


### PR DESCRIPTION
Intended as a primitive patch for https://github.com/TelemetryDeck/KotlinSDK/issues/88

No code removal has been done. `asMultiValueDimension` is still intact.

Tests have been updated and are passing.

This aligns the `payload` structure as the SwiftSDK is delivering it.