### PR TITLE
Fix session tracking issues

### DIFF
--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProvider.kt
@@ -2,6 +2,7 @@ package com.telemetrydeck.sdk.providers
 
 import android.content.Context
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.telemetrydeck.sdk.DateSerializer
@@ -44,6 +45,11 @@ class SessionTrackingSignalProvider: TelemetryDeckSessionManagerProvider, Defaul
         this.manager = WeakReference(client)
         this.appContext = WeakReference(ctx)
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+        
+        // Check if the process is already in foreground and initialize session tracking immediately
+        if (ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            handleOnForeground()
+        }
     }
 
     @Synchronized


### PR DESCRIPTION
If the `start` method is called when the app is already in the foreground `handleOnForeground()` is never called. So this will force call it on those cases.

- Add lifecycle state check in register() method to handle cases where TelemetryDeck is initialized after the app process is already in the foreground
- Call handleOnForeground() immediately if process is already STARTED or RESUMED
- Fixes issue where session IDs were null and session signals were missing
- Resolves issue #91 