### PR TITLE
Update README and Maven Publishing version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The Kotlin SDK for TelemetryDeck is available from Maven Central at the followin
 ```groovy
 // `build.gradle`
 dependencies {
-    implementation 'com.telemetrydeck:kotlin-sdk:6.2.0'
+    implementation 'com.telemetrydeck:kotlin-sdk:6.2.1'
 }
 ```
 
 ```kotlin
 // `build.gradle.kts`
 dependencies {
-    implementation("com.telemetrydeck:kotlin-sdk:6.2.0")
+    implementation("com.telemetrydeck:kotlin-sdk:6.2.1")
 }
 ```
 
@@ -487,7 +487,7 @@ When integrating with Google Play Billing Library, you can adopt the TelemetryDe
 ```kotlin
 // `build.gradle.kts`
 dependencies {
-    implementation("com.telemetrydeck:kotlin-sdk-google-services:6.2.0")
+    implementation("com.telemetrydeck:kotlin-sdk-google-services:6.2.1")
 }
 ```
 

--- a/google-services/build.gradle.kts
+++ b/google-services/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.telemetrydeck", "kotlin-sdk-google-services", "6.2.0")
+    coordinates("com.telemetrydeck", "kotlin-sdk-google-services", "6.2.1")
 
     pom {
         name = "TelemetryDeck SDK Google Services"

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -107,7 +107,7 @@ dependencies {
 }
 
 mavenPublishing {
-    coordinates("com.telemetrydeck", "kotlin-sdk", "6.2.0")
+    coordinates("com.telemetrydeck", "kotlin-sdk", "6.2.1")
 
     pom {
         name = "TelemetryDeck SDK"

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/EnvironmentParameterProvider.kt
@@ -29,7 +29,7 @@ class EnvironmentParameterProvider : TelemetryDeckProvider {
     private val platform: String = "Android"
     private val os: String = "Android"
     private val sdkName: String = "KotlinSDK"
-    private val sdkVersion: String = "6.2.0"
+    private val sdkVersion: String = "6.2.1"
 
     override fun register(ctx: Context?, client: TelemetryDeckSignalProcessor) {
         appendContextSpecificParams(ctx, client.debugLogger)


### PR DESCRIPTION
Apologies if I did this wrong—or if this is a faux pas—but a new version was tagged but not updated for maven publishing and in the readme. This PR is for updating those to 6.2.1.

I'm not positive if the google-services number needed to be updated but I went ahead and did so.