### PR TITLE
Add pirate metrics Activation helpers

### DIFF
--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -3,6 +3,7 @@ package com.telemetrydeck.sdk
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import com.telemetrydeck.sdk.params.Acquisition
+import com.telemetrydeck.sdk.params.Activation
 import com.telemetrydeck.sdk.params.Navigation
 import com.telemetrydeck.sdk.providers.AccessibilityProvider
 import com.telemetrydeck.sdk.providers.CalendarParameterProvider
@@ -101,6 +102,36 @@ class TelemetryDeck(
         ))
         signal(
             com.telemetrydeck.sdk.signals.Acquisition.LeadConverted.signalName,
+            params = signalParams,
+            customUserID = customUserID
+        )
+    }
+
+    @ExperimentalFeature
+    override fun onboardingCompleted(
+        params: Map<String, String>,
+        customUserID: String?
+    ) {
+        signal(
+            com.telemetrydeck.sdk.signals.Activation.OnboardingCompleted.signalName,
+            params = params,
+            customUserID = customUserID
+        )
+    }
+
+    @ExperimentalFeature
+    override fun coreFeatureUsed(
+        featureName: String,
+        params: Map<String, String>,
+        customUserID: String?
+    ) {
+        val signalParams = mergeMapsWithOverwrite(
+            params, mapOf(
+                Activation.FeatureName.paramName to featureName
+            )
+        )
+        signal(
+            com.telemetrydeck.sdk.signals.Activation.CoreFeatureUsed.signalName,
             params = signalParams,
             customUserID = customUserID
         )
@@ -424,6 +455,23 @@ class TelemetryDeck(
             customUserID: String?
         ) {
             getInstance()?.leadConverted(leadId, params, customUserID)
+        }
+
+        @ExperimentalFeature
+        override fun onboardingCompleted(
+            params: Map<String, String>,
+            customUserID: String?
+        ) {
+            getInstance()?.onboardingCompleted(params, customUserID)
+        }
+
+        @ExperimentalFeature
+        override fun coreFeatureUsed(
+            featureName: String,
+            params: Map<String, String>,
+            customUserID: String?
+        ) {
+            getInstance()?.coreFeatureUsed(featureName, params, customUserID)
         }
 
         override suspend fun send(

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -53,6 +53,21 @@ interface TelemetryDeckClient {
     @ExperimentalFeature
     fun leadConverted(leadId: String, params: Map<String, String> = emptyMap(), customUserID: String? = null)
 
+    /**
+     * Send a `TelemetryDeck.Activation.onboardingCompleted` signal.
+     */
+    @ExperimentalFeature
+    fun onboardingCompleted(params: Map<String, String> = emptyMap(), customUserID: String? = null)
+
+    /**
+     * Send a `TelemetryDeck.Activation.coreFeatureUsed` signal.
+     */
+    @ExperimentalFeature
+    fun coreFeatureUsed(
+        featureName: String,
+        params: Map<String, String> = emptyMap(),
+        customUserID: String? = null
+    )
 
     /**
      * Send a signal immediately

--- a/lib/src/main/java/com/telemetrydeck/sdk/params/Activation.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/params/Activation.kt
@@ -1,0 +1,5 @@
+package com.telemetrydeck.sdk.params
+
+enum class Activation(val paramName: String) {
+    FeatureName("TelemetryDeck.Activation.featureName"),
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/signals/Acquisition.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/signals/Acquisition.kt
@@ -1,6 +1,6 @@
 package com.telemetrydeck.sdk.signals
 
-internal enum class Acquisition(val signalName: String) {
+enum class Acquisition(val signalName: String) {
     NewInstallDetected("TelemetryDeck.Acquisition.newInstallDetected"),
     LeadStarted("TelemetryDeck.Acquisition.leadStarted"),
     UserAcquired("TelemetryDeck.Acquisition.userAcquired"),

--- a/lib/src/main/java/com/telemetrydeck/sdk/signals/Activation.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/signals/Activation.kt
@@ -1,0 +1,6 @@
+package com.telemetrydeck.sdk.signals
+
+internal enum class Activation(val signalName: String) {
+    OnboardingCompleted("TelemetryDeck.Activation.onboardingCompleted"),
+    CoreFeatureUsed("TelemetryDeck.Activation.coreFeatureUsed"),
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckTests.kt
@@ -234,6 +234,37 @@ class TelemetryDeckTests {
     }
 
     @Test
+    fun telemetryDeck_coreFeatureUsed_sends_featureName() {
+        val builder = TelemetryDeck.Builder()
+        val sut = builder
+            .appID("32CB6574-6732-4238-879F-582FEBEB6536")
+            .build(null)
+        sut.coreFeatureUsed("feature 1")
+
+        val signal = sut.cache?.empty()?.firstOrNull()
+
+        Assert.assertNotNull(signal)
+        Assert.assertEquals("TelemetryDeck.Activation.coreFeatureUsed", signal?.type)
+        Assert.assertEquals(
+            "TelemetryDeck.Activation.featureName:feature 1",
+            signal?.payload?.firstOrNull { it.startsWith("TelemetryDeck.Activation.featureName:") })
+    }
+
+    @Test
+    fun telemetryDeck_onboardingCompleted_sends_onboardingCompleted() {
+        val builder = TelemetryDeck.Builder()
+        val sut = builder
+            .appID("32CB6574-6732-4238-879F-582FEBEB6536")
+            .build(null)
+        sut.onboardingCompleted()
+
+        val signal = sut.cache?.empty()?.firstOrNull()
+
+        Assert.assertNotNull(signal)
+        Assert.assertEquals("TelemetryDeck.Activation.onboardingCompleted", signal?.type)
+    }
+
+    @Test
     fun telemetryDeck_addProvider_appends_after_default_providers() {
         val builder = TelemetryDeck.Builder()
         val sut = builder


### PR DESCRIPTION
This PR adds the following helper methods:

```kotlin
/**
    * Send a `TelemetryDeck.Activation.onboardingCompleted` signal.
    */
fun onboardingCompleted(params: Map<String, String> = emptyMap(), customUserID: String? = null)

/**
    * Send a `TelemetryDeck.Activation.coreFeatureUsed` signal.
    */
fun coreFeatureUsed(
    featureName: String,
    params: Map<String, String> = emptyMap(),
    customUserID: String? = null
)
```