### PR TITLE
Introduce cache cap, backoff when retrying previously failed events

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-serialization-properties = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-properties", version.ref = "kotlinx" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "datetime" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 mockk = {group = "io.mockk", name = "mockk", version.ref = "mockk" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.androidx.arch.core)
+    testImplementation(libs.kotlinx.coroutines.test)
     // As of Kotlin 2.0, the Compose Compiler and runtime are required in the classpath https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html
     testImplementation(libs.androidx.activity.compose)
     testImplementation(platform(libs.androidx.compose.bom))

--- a/lib/src/main/java/com/telemetrydeck/sdk/MemorySignalCache.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/MemorySignalCache.kt
@@ -1,11 +1,32 @@
 package com.telemetrydeck.sdk
 
-class MemorySignalCache(private var signalQueue: MutableList<Signal> = mutableListOf()) :
-    SignalCache {
+class MemorySignalCache(
+    private val cacheLimit: Int = Int.MAX_VALUE,
+    private var signalQueue: MutableList<Signal> = mutableListOf(),
+) : SignalCache {
+
+    init {
+        require(cacheLimit > 0) { "cacheLimit must be greater than zero" }
+    }
 
     override fun add(signal: Signal) {
         synchronized(this) {
+            if (signalQueue.size >= cacheLimit) {
+                val overflow = signalQueue.size - cacheLimit + 1
+                repeat(overflow) { signalQueue.removeAt(0) }
+            }
             signalQueue.add(signal)
+        }
+    }
+
+    override fun addAll(signals: List<Signal>) {
+        if (signals.isEmpty()) return
+        synchronized(this) {
+            signalQueue.addAll(signals)
+            if (signalQueue.size > cacheLimit) {
+                val overflow = signalQueue.size - cacheLimit
+                repeat(overflow) { signalQueue.removeAt(0) }
+            }
         }
     }
 

--- a/lib/src/main/java/com/telemetrydeck/sdk/PersistentSignalCache.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/PersistentSignalCache.kt
@@ -1,20 +1,45 @@
 package com.telemetrydeck.sdk
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
 
-class PersistentSignalCache(private var signalQueue: MutableList<Signal> = mutableListOf()) :
-    SignalCache {
+class PersistentSignalCache(
+    private val cacheLimit: Int = 10_000,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1),
+    private var signalQueue: MutableList<Signal> = mutableListOf(),
+) : SignalCache {
     val cacheFileName: String = "telemetrydeck.json"
     private var file: File? = null
 
-    constructor(cacheDir: File, logger: DebugLogger?) : this() {
+    private val ioScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val saveRequests = Channel<Unit>(Channel.CONFLATED)
+
+    init {
+        require(cacheLimit > 0) { "cacheLimit must be greater than zero" }
+        ioScope.launch {
+            for (request in saveRequests) {
+                saveSignals()
+            }
+        }
+    }
+
+    constructor(
+        cacheDir: File,
+        logger: DebugLogger?,
+        cacheLimit: Int = 10_000,
+        ioDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1),
+    ) : this(cacheLimit = cacheLimit, ioDispatcher = ioDispatcher) {
         if (!cacheDir.isDirectory) {
             logger?.error("Expected a folder but received a file instead.")
             return
         }
-
         val writeFile = File(cacheDir, cacheFileName)
         logger?.debug("Using signal cache at ${writeFile.absolutePath}.")
         if (writeFile.exists()) {
@@ -22,44 +47,69 @@ class PersistentSignalCache(private var signalQueue: MutableList<Signal> = mutab
             val content = writeFile.readText()
             try {
                 val oldSignals: List<Signal> = Json.decodeFromString(content)
-                logger?.error("Restoring ${oldSignals.count()} signals from cache.")
-                signalQueue.addAll(oldSignals)
+                val trimmed = if (oldSignals.size > cacheLimit) {
+                    logger?.debug("Restored cache exceeds cacheLimit ($cacheLimit), dropping ${oldSignals.size - cacheLimit} oldest signals")
+                    oldSignals.takeLast(cacheLimit)
+                } else {
+                    oldSignals
+                }
+                logger?.debug("Restoring ${trimmed.count()} signals from cache.")
+                signalQueue.addAll(trimmed)
             } catch (e: Exception) {
                 logger?.error("Failed to parse signal cache.")
             }
         }
         file = writeFile
-        saveSignals()
+        scheduleSave()
     }
 
     override fun add(signal: Signal) {
         synchronized(this) {
+            if (signalQueue.size >= cacheLimit) {
+                val overflow = signalQueue.size - cacheLimit + 1
+                repeat(overflow) { signalQueue.removeAt(0) }
+            }
             signalQueue.add(signal)
-            saveSignals()
         }
+        scheduleSave()
+    }
 
+    override fun addAll(signals: List<Signal>) {
+        if (signals.isEmpty()) return
+        synchronized(this) {
+            signalQueue.addAll(signals)
+            if (signalQueue.size > cacheLimit) {
+                val overflow = signalQueue.size - cacheLimit
+                repeat(overflow) { signalQueue.removeAt(0) }
+            }
+        }
+        scheduleSave()
     }
 
     override fun empty(): List<Signal> {
+        val items: List<Signal>
         synchronized(this) {
-            val items = signalQueue.toList()
+            items = signalQueue.toList()
             signalQueue = mutableListOf()
-            saveSignals()
-            return items
         }
+        scheduleSave()
+        return items
     }
 
-    override fun count(): Int {
-        synchronized(this) {
-            return signalQueue.count()
-        }
+    override fun count(): Int = synchronized(this) { signalQueue.count() }
+
+    private fun scheduleSave() {
+        saveRequests.trySend(Unit)
     }
 
     private fun saveSignals() {
-        // make sure the parent folder exists before writing
+        val snapshot: List<Signal>
+        synchronized(this) {
+            snapshot = signalQueue.toList()
+        }
         file?.parentFile?.mkdirs()
         file?.createNewFile()
-        val json = Json.encodeToString(signalQueue)
+        val json = Json.encodeToString(snapshot)
         file?.writeText(json)
     }
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/SignalCache.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/SignalCache.kt
@@ -7,6 +7,11 @@ interface SignalCache {
     fun add(signal: Signal)
 
     /**
+     * Appends multiple signals to the cache in a single operation
+     */
+    fun addAll(signals: List<Signal>)
+
+    /**
      * Empties the cache and returns all previously cached items
      */
     fun empty(): List<Signal>

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryBroadcastTimer.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryBroadcastTimer.kt
@@ -3,65 +3,88 @@ package com.telemetrydeck.sdk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.channels.ticker
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.CoroutineContext
 
 internal class TelemetryBroadcastTimer(
     private val manager: WeakReference<TelemetryDeckSignalProcessor>,
-    debugLogger: WeakReference<DebugLogger>
+    debugLogger: WeakReference<DebugLogger>,
+    private val transmitInterval: Long = 10_000L,
+    private val maxBackoffInterval: Long = 300_000L,
+    coroutineContext: CoroutineContext = SupervisorJob() + Dispatchers.IO,
 ) {
-
-    // broadcast begins with a 10s delay after initialization and fires every 10s.
-    private val timerChannel = ticker(delayMillis = 10_000, initialDelayMillis = 10_000)
     private var logger: DebugLogger? = null
+    private val consecutiveFailures = AtomicInteger(0)
+    private val scope = CoroutineScope(coroutineContext)
+    private var job: Job? = null
 
     init {
         this.logger = debugLogger.get()
     }
 
-    private var job: Job? = null
+    internal fun nextInterval(): Long = nextInterval(consecutiveFailures.get())
+
+    internal fun nextInterval(failures: Int): Long {
+        if (failures == 0) return transmitInterval
+        // Clamp the exponent to 16 to guard against Long overflow; maxBackoffInterval caps the result in practice.
+        val factor = 1L shl minOf(failures, 16)
+        return minOf(transmitInterval * factor, maxBackoffInterval)
+    }
+
+    internal fun resetBackoff() {
+        consecutiveFailures.set(0)
+    }
+
+    internal fun currentBackoffFailures(): Int = consecutiveFailures.get()
 
     fun start() {
-        CoroutineScope(Dispatchers.IO).launch {
-            job?.cancel()
-            job?.join()
-            job = launch {
-                for (event in timerChannel) {
-                    val managerInstance = manager.get()
-                        ?: // can't broadcast without a manager to provide signals
-                        continue
-
-                    val cache = managerInstance.signalCache
-
-                    if (cache == null) {
-                        logger?.debug("Signal cache is not available")
-                        continue
-                    }
-
-                    val signals = cache.empty()
-                    if (signals.isEmpty()) {
-                        // no signals to broadcast
-                        logger?.debug("Signal cache is empty, no signals to broadcast")
-                        continue
-                    }
-
-                    logger?.debug("Broadcasting ${signals.count()} cached signals")
-                    if (managerInstance.sendAll(signals).isFailure) {
-                        logger?.debug("Failed to broadcast cached signals, re-enqueueing ${signals.count()} signals for later")
-                        for (failedSignal in signals) {
-                            cache.add(failedSignal)
-                        }
-                    }
-                }
+        job?.cancel()
+        job = scope.launch {
+            while (isActive) {
+                delay(nextInterval())
+                transmitBatch()
             }
         }
         logger?.debug("Started timer broadcast")
     }
 
     fun stop() {
-        CoroutineScope(Dispatchers.IO).launch {
-            job?.cancel()
+        job?.cancel()
+        job = null
+    }
+
+    /**
+     * Immediately transmits all cached events without waiting for the next timer tick, resets the backoff counter to 0 before transmitting.
+     */
+    internal suspend fun flush() {
+        consecutiveFailures.set(0)
+        transmitBatch()
+    }
+
+    private suspend fun transmitBatch() {
+        val managerInstance = manager.get() ?: return
+        val cache = managerInstance.signalCache
+        if (cache == null) {
+            logger?.debug("Signal cache is not available")
+            return
+        }
+        val signals = cache.empty()
+        if (signals.isEmpty()) {
+            logger?.debug("Signal cache is empty, no signals to broadcast")
+            return
+        }
+        logger?.debug("Broadcasting ${signals.count()} cached signals")
+        if (managerInstance.sendAll(signals).isFailure) {
+            logger?.debug("Failed to broadcast cached signals, re-enqueueing ${signals.count()} signals for later")
+            consecutiveFailures.incrementAndGet()
+            cache.addAll(signals)
+        } else {
+            consecutiveFailures.set(0)
         }
     }
 }

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -21,6 +21,7 @@ import java.security.MessageDigest
 import java.util.UUID
 import kotlin.Result.Companion.failure
 import kotlin.Result.Companion.success
+import kotlinx.serialization.SerializationException
 
 class TelemetryDeck(
     override val configuration: TelemetryManagerConfiguration,
@@ -234,6 +235,10 @@ class TelemetryDeck(
         return send(signals)
     }
 
+    override suspend fun flush() {
+        broadcastTimer?.flush()
+    }
+
     override fun processSignal(
         signalName: String,
         params: Map<String, String>,
@@ -358,6 +363,11 @@ class TelemetryDeck(
                 logger,
             )
             client.send(signals)
+            broadcastTimer?.resetBackoff()
+            success(Unit)
+        } catch (e: SerializationException) {
+            logger?.error("Failed to encode ${signals.size} signals, dropping batch: $e")
+            broadcastTimer?.resetBackoff()
             success(Unit)
         } catch (e: Exception) {
             logger?.error("Failed to send signals due to an error $e ${e.stackTraceToString()}")
@@ -611,6 +621,10 @@ class TelemetryDeck(
             return failure(NullPointerException())
         }
 
+        override suspend fun flush() {
+            getInstance()?.flush()
+        }
+
         override fun processSignal(
             signalName: String,
             params: Map<String, String>,
@@ -713,6 +727,8 @@ class TelemetryDeck(
         private var telemetryClientFactory: TelemetryApiClientFactory? = null,
         private var signalCache: SignalCache? = null,
         private var namespace: String? = null,
+        private var transmitInterval: Long? = null,
+        private var maxBackoffInterval: Long? = null,
     ) {
         /**
          * Set the [TelemetryDeck] configuration.
@@ -793,6 +809,16 @@ class TelemetryDeck(
 
         fun signalCache(cache: SignalCache) = apply {
             this.signalCache = cache
+        }
+
+        fun transmitInterval(intervalMs: Long) = apply {
+            require(intervalMs > 0) { "intervalMs must be greater than zero" }
+            this.transmitInterval = intervalMs
+        }
+
+        fun maxBackoffInterval(intervalMs: Long) = apply {
+            require(intervalMs > 0) { "intervalMs must be greater than zero" }
+            this.maxBackoffInterval = intervalMs
         }
 
         /**
@@ -881,8 +907,12 @@ class TelemetryDeck(
                 manager.telemetryClientFactory = telemetryClientFactory as TelemetryApiClientFactory
             }
 
-            val broadcaster =
-                TelemetryBroadcastTimer(WeakReference(manager), WeakReference(manager.logger))
+            val broadcaster = TelemetryBroadcastTimer(
+                manager = WeakReference(manager),
+                debugLogger = WeakReference(manager.logger),
+                transmitInterval = this.transmitInterval ?: 10_000L,
+                maxBackoffInterval = this.maxBackoffInterval ?: 300_000L,
+            )
             manager.broadcastTimer = broadcaster
 
             if (signalCache != null) {

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -454,6 +454,18 @@ class TelemetryDeck(
         @Volatile
         internal var instance: TelemetryDeck? = null
 
+        private fun missingInstance(operation: String): Nothing? {
+            TelemetryManagerDebugLogger.error(
+                "TelemetryDeck.$operation called before initialization. Call TelemetryDeck.start(context, Builder()...) in Application.onCreate() to enable telemetry."
+            )
+            return null
+        }
+
+        private inline fun <T> requireInstance(operation: String, block: (TelemetryDeck) -> T): T? {
+            val current = getInstance() ?: return missingInstance(operation)
+            return block(current)
+        }
+
         /**
          * Builds and starts the application instance of [TelemetryDeck].
          * Calling this method multiple times has no effect.
@@ -509,19 +521,19 @@ class TelemetryDeck(
         }
 
         override fun newSession(sessionID: UUID) {
-            getInstance()?.newSession(sessionID)
+            requireInstance("newSession") { it.newSession(sessionID) }
         }
 
         override fun newDefaultUser(user: String?) {
-            getInstance()?.newDefaultUser(user)
+            requireInstance("newDefaultUser") { it.newDefaultUser(user) }
         }
 
         override fun navigate(sourcePath: String, destinationPath: String, clientUser: String?) {
-            getInstance()?.navigate(sourcePath, destinationPath, clientUser = clientUser)
+            requireInstance("navigate") { it.navigate(sourcePath, destinationPath, clientUser = clientUser) }
         }
 
         override fun navigate(destinationPath: String, customUserID: String?) {
-            getInstance()?.navigate(destinationPath, customUserID = customUserID)
+            requireInstance("navigate") { it.navigate(destinationPath, customUserID = customUserID) }
         }
 
         override fun acquiredUser(
@@ -529,7 +541,7 @@ class TelemetryDeck(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.acquiredUser(channel, params, customUserID)
+            requireInstance("acquiredUser") { it.acquiredUser(channel, params, customUserID) }
         }
 
         override fun leadStarted(
@@ -537,7 +549,7 @@ class TelemetryDeck(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.leadStarted(leadId, params, customUserID)
+            requireInstance("leadStarted") { it.leadStarted(leadId, params, customUserID) }
         }
 
         override fun leadConverted(
@@ -545,14 +557,14 @@ class TelemetryDeck(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.leadConverted(leadId, params, customUserID)
+            requireInstance("leadConverted") { it.leadConverted(leadId, params, customUserID) }
         }
 
         override fun onboardingCompleted(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.onboardingCompleted(params, customUserID)
+            requireInstance("onboardingCompleted") { it.onboardingCompleted(params, customUserID) }
         }
 
         override fun coreFeatureUsed(
@@ -560,7 +572,7 @@ class TelemetryDeck(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.coreFeatureUsed(featureName, params, customUserID)
+            requireInstance("coreFeatureUsed") { it.coreFeatureUsed(featureName, params, customUserID) }
         }
 
         override fun paywallShown(
@@ -568,7 +580,7 @@ class TelemetryDeck(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.paywallShown(reason, params, customUserID)
+            requireInstance("paywallShown") { it.paywallShown(reason, params, customUserID) }
         }
 
         override fun referralSent(
@@ -577,7 +589,7 @@ class TelemetryDeck(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.referralSent(receiversCount, kind, params, customUserID)
+            requireInstance("referralSent") { it.referralSent(receiversCount, kind, params, customUserID) }
         }
 
         override fun userRatingSubmitted(
@@ -586,7 +598,7 @@ class TelemetryDeck(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.userRatingSubmitted(rating, comment, params, customUserID)
+            requireInstance("userRatingSubmitted") { it.userRatingSubmitted(rating, comment, params, customUserID) }
         }
 
         override fun errorOccurred(
@@ -597,7 +609,7 @@ class TelemetryDeck(
             floatValue: Double?,
             customUserID: String?
         ) {
-            getInstance()?.errorOccurred(id, category, message, parameters, floatValue, customUserID)
+            requireInstance("errorOccurred") { it.errorOccurred(id, category, message, parameters, floatValue, customUserID) }
         }
 
         override suspend fun send(
@@ -606,23 +618,23 @@ class TelemetryDeck(
             additionalPayload: Map<String, String>,
             floatValue: Double?
         ): Result<Unit> {
-            val result = getInstance()?.send(signalType, clientUser, additionalPayload, floatValue)
-            if (result != null) {
-                return result
+            val current = getInstance() ?: run {
+                missingInstance("send")
+                return failure(IllegalStateException("TelemetryDeck not initialized"))
             }
-            return failure(NullPointerException())
+            return current.send(signalType, clientUser, additionalPayload, floatValue)
         }
 
         override suspend fun sendAll(signals: List<Signal>): Result<Unit> {
-            val result = getInstance()?.sendAll(signals)
-            if (result != null) {
-                return result
+            val current = getInstance() ?: run {
+                missingInstance("sendAll")
+                return failure(IllegalStateException("TelemetryDeck not initialized"))
             }
-            return failure(NullPointerException())
+            return current.sendAll(signals)
         }
 
         override suspend fun flush() {
-            getInstance()?.flush()
+            requireInstance("flush") { it.flush() }
         }
 
         override fun processSignal(
@@ -644,7 +656,7 @@ class TelemetryDeck(
             floatValue: Double?,
             customUserID: String?
         ) {
-            getInstance()?.signal(signalName, params, floatValue, customUserID)
+            requireInstance("signal") { it.signal(signalName, params, floatValue, customUserID) }
         }
 
         override fun signal(
@@ -652,15 +664,11 @@ class TelemetryDeck(
             customUserID: String?,
             params: Map<String, String>
         ) {
-            getInstance()?.signal(
-                signalName = signalName,
-                customUserID = customUserID,
-                params = params
-            )
+            requireInstance("signal") { it.signal(signalName = signalName, customUserID = customUserID, params = params) }
         }
 
         override fun startDurationSignal(signalName: String, parameters: Map<String, String>, includeBackgroundTime: Boolean) {
-            getInstance()?.startDurationSignal(signalName, parameters, includeBackgroundTime)
+            requireInstance("startDurationSignal") { it.startDurationSignal(signalName, parameters, includeBackgroundTime) }
         }
 
         override fun stopAndSendDurationSignal(
@@ -669,7 +677,7 @@ class TelemetryDeck(
             floatValue: Double?,
             customUserID: String?
         ) {
-            getInstance()?.stopAndSendDurationSignal(signalName, parameters, floatValue, customUserID)
+            requireInstance("stopAndSendDurationSignal") { it.stopAndSendDurationSignal(signalName, parameters, floatValue, customUserID) }
         }
 
         override fun purchaseCompleted(
@@ -683,17 +691,19 @@ class TelemetryDeck(
             params: Map<String, String>,
             customUserID: String?
         ) {
-            getInstance()?.purchaseCompleted(
-                event,
-                countryCode,
-                productID,
-                purchaseType,
-                priceAmountMicros,
-                currencyCode,
-                offerID,
-                params,
-                customUserID
-            )
+            requireInstance("purchaseCompleted") {
+                it.purchaseCompleted(
+                    event,
+                    countryCode,
+                    productID,
+                    purchaseType,
+                    priceAmountMicros,
+                    currencyCode,
+                    offerID,
+                    params,
+                    customUserID
+                )
+            }
         }
 
         override val signalCache: SignalCache?

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeckClient.kt
@@ -95,6 +95,11 @@ interface TelemetryDeckClient {
     )
 
     /**
+     * Immediately transmits all queued events without waiting for the next scheduled interval, resets the backoff counter to 0 before transmitting.
+     */
+    suspend fun flush()
+
+    /**
      * Send a signal immediately
      */
     suspend fun send(

--- a/lib/src/test/java/com/telemetrydeck/sdk/MemorySignalCacheTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/MemorySignalCacheTest.kt
@@ -55,4 +55,84 @@ class MemorySignalCacheTest {
         Assert.assertEquals(signal2.type, signals[1].type)
         Assert.assertEquals(signal2.clientUser, signals[1].clientUser)
     }
+
+    @Test
+    fun cacheLimit_evictsOldestOnOverflow() {
+        val sut = MemorySignalCache(cacheLimit = 3)
+        for (i in 1..5) {
+            sut.add(Signal(appID = UUID.randomUUID(), "type$i", "user", SignalPayload()))
+        }
+
+        Assert.assertEquals(3, sut.count())
+        val signals = sut.empty()
+        Assert.assertEquals("type3", signals[0].type)
+        Assert.assertEquals("type4", signals[1].type)
+        Assert.assertEquals("type5", signals[2].type)
+    }
+
+    @Test
+    fun noEvictionBelowLimit() {
+        val sut = MemorySignalCache(cacheLimit = 5)
+        for (i in 1..3) {
+            sut.add(Signal(appID = UUID.randomUUID(), "type$i", "user", SignalPayload()))
+        }
+
+        Assert.assertEquals(3, sut.count())
+    }
+
+    @Test
+    fun defaultLimitIsUnbounded() {
+        val sut = MemorySignalCache()
+        for (i in 1..10_001) {
+            sut.add(Signal(appID = UUID.randomUUID(), "type$i", "user", SignalPayload()))
+        }
+
+        Assert.assertEquals(10_001, sut.count())
+    }
+
+    @Test
+    fun addAll_appendsAllSignals() {
+        val sut = MemorySignalCache()
+        sut.addAll((1..5).map { Signal(appID = UUID.randomUUID(), "type$it", "user", SignalPayload()) })
+
+        Assert.assertEquals(5, sut.count())
+    }
+
+    @Test
+    fun addAll_respectsCacheLimit() {
+        val sut = MemorySignalCache(cacheLimit = 3)
+        sut.addAll((1..7).map { Signal(appID = UUID.randomUUID(), "type$it", "user", SignalPayload()) })
+
+        Assert.assertEquals(3, sut.count())
+        val survivors = sut.empty()
+        Assert.assertEquals("type5", survivors[0].type)
+        Assert.assertEquals("type6", survivors[1].type)
+        Assert.assertEquals("type7", survivors[2].type)
+    }
+
+    @Test
+    fun addAll_acrossExistingQueue_evictsOldest() {
+        val sut = MemorySignalCache(cacheLimit = 3)
+        sut.add(Signal(appID = UUID.randomUUID(), "a", "user", SignalPayload()))
+        sut.add(Signal(appID = UUID.randomUUID(), "b", "user", SignalPayload()))
+        sut.addAll(listOf(
+            Signal(appID = UUID.randomUUID(), "c", "user", SignalPayload()),
+            Signal(appID = UUID.randomUUID(), "d", "user", SignalPayload()),
+            Signal(appID = UUID.randomUUID(), "e", "user", SignalPayload()),
+        ))
+
+        Assert.assertEquals(3, sut.count())
+        val survivors = sut.empty()
+        Assert.assertEquals("c", survivors[0].type)
+        Assert.assertEquals("d", survivors[1].type)
+        Assert.assertEquals("e", survivors[2].type)
+    }
+
+    @Test
+    fun addAll_emptyListIsNoop() {
+        val sut = MemorySignalCache()
+        sut.addAll(emptyList())
+
+        Assert.assertEquals(0, sut.count())
+    }
 }

--- a/lib/src/test/java/com/telemetrydeck/sdk/PersistentSignalCacheTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/PersistentSignalCacheTest.kt
@@ -1,11 +1,19 @@
 package com.telemetrydeck.sdk
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.Assert
 import org.junit.Rule
@@ -13,7 +21,9 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.util.UUID
+import kotlin.coroutines.CoroutineContext
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class PersistentSignalCacheTest {
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -21,18 +31,21 @@ class PersistentSignalCacheTest {
     @get:Rule
     var folder = TemporaryFolder()
 
+    private fun makeSignal(type: String = "type", user: String = "user") =
+        Signal(UUID.randomUUID(), type, user, SignalPayload())
+
     @Test
-    fun persistentSignalCache_starts_with_empty_queue() {
+    fun persistentSignalCache_starts_with_empty_queue() = runTest(UnconfinedTestDispatcher()) {
         val cacheDir = folder.newFolder()
-        val sut = PersistentSignalCache(cacheDir, null)
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = UnconfinedTestDispatcher())
 
         Assert.assertEquals(0, sut.count())
     }
 
     @Test
-    fun persistentSignalCache_creates_cache_file() {
+    fun persistentSignalCache_creates_cache_file() = runTest(UnconfinedTestDispatcher()) {
         val cacheDir = folder.newFolder()
-        val sut = PersistentSignalCache(cacheDir, null)
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = UnconfinedTestDispatcher())
 
         val cacheFile = File(cacheDir, sut.cacheFileName)
 
@@ -44,10 +57,10 @@ class PersistentSignalCacheTest {
     }
 
     @Test
-    fun persistentSignalCache_new_signals_added_to_cache() {
+    fun persistentSignalCache_new_signals_added_to_cache() = runTest(UnconfinedTestDispatcher()) {
         val cacheDir = folder.newFolder()
-        val sut = PersistentSignalCache(cacheDir, null)
-        sut.add(Signal(UUID.randomUUID(), "type", "user", SignalPayload()))
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = UnconfinedTestDispatcher())
+        sut.add(makeSignal("type", "user"))
         val cacheFile = File(cacheDir, sut.cacheFileName)
 
         val json = cacheFile.readText()
@@ -58,10 +71,10 @@ class PersistentSignalCacheTest {
     }
 
     @Test
-    fun persistentSignalCache_empty_clears_cache() {
+    fun persistentSignalCache_empty_clears_cache() = runTest(UnconfinedTestDispatcher()) {
         val cacheDir = folder.newFolder()
-        val sut = PersistentSignalCache(cacheDir, null)
-        sut.add(Signal(UUID.randomUUID(), "type", "user", SignalPayload()))
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = UnconfinedTestDispatcher())
+        sut.add(makeSignal())
         sut.empty()
         val cacheFile = File(cacheDir, sut.cacheFileName)
 
@@ -70,33 +83,169 @@ class PersistentSignalCacheTest {
         Assert.assertEquals(0, signals.count())
     }
 
+    @Test
+    fun cacheLimit_evictsOldestOnOverflow() = runTest(UnconfinedTestDispatcher()) {
+        val cacheDir = folder.newFolder()
+        val sut = PersistentSignalCache(cacheDir, null, cacheLimit = 3, ioDispatcher = UnconfinedTestDispatcher())
+        for (i in 1..5) {
+            sut.add(makeSignal("type$i"))
+        }
+
+        Assert.assertEquals(3, sut.count())
+        val cacheFile = File(cacheDir, sut.cacheFileName)
+        val json = cacheFile.readText()
+        val signals = Json.decodeFromString<List<Signal>>(json)
+        Assert.assertEquals(3, signals.count())
+        Assert.assertEquals("type3", signals[0].type)
+        Assert.assertEquals("type4", signals[1].type)
+        Assert.assertEquals("type5", signals[2].type)
+    }
+
+    @Test
+    fun restoreTrimsToLimit() = runTest(UnconfinedTestDispatcher()) {
+        val cacheDir = folder.newFolder()
+        val cacheFile = File(cacheDir, "telemetrydeck.json")
+        val preexisting = (1..5).map { i -> makeSignal("type$i") }
+        cacheFile.writeText(Json.encodeToString(preexisting))
+
+        val sut = PersistentSignalCache(cacheDir, null, cacheLimit = 3, ioDispatcher = UnconfinedTestDispatcher())
+
+        Assert.assertEquals(3, sut.count())
+        val signals = sut.empty()
+        Assert.assertEquals("type3", signals[0].type)
+        Assert.assertEquals("type4", signals[1].type)
+        Assert.assertEquals("type5", signals[2].type)
+    }
+
+    @Test
+    fun defaultLimitIsTenThousand() = runTest(UnconfinedTestDispatcher()) {
+        val cacheDir = folder.newFolder()
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = UnconfinedTestDispatcher())
+        for (i in 1..10_001) {
+            sut.add(makeSignal("type$i"))
+        }
+
+        Assert.assertEquals(10_000, sut.count())
+    }
+
     @DelicateCoroutinesApi
     @Test
     fun persistentSignalCache_allows_adding_signals_concurrently() = runBlocking {
         val cacheDir = folder.newFolder()
-        val sut = PersistentSignalCache(cacheDir, null)
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = UnconfinedTestDispatcher())
 
-        // the cache should accept signals from concurrent coroutines
         val scope = CoroutineScope(newFixedThreadPoolContext(4, "pool"))
         scope.launch {
             val coroutines = 1.rangeTo(100).map {
-                // create 100 coroutines (light-weight threads).
                 launch {
-                    for (i in 1..20) { // and in each of them, add 20 signals
-                        sut.add(Signal(UUID.randomUUID(), "type", "user", SignalPayload()))
+                    for (i in 1..20) {
+                        sut.add(makeSignal())
                     }
                 }
             }
-
-            coroutines.forEach { coroutine ->
-                coroutine.join() // wait for all coroutines to finish their jobs.
-            }
+            coroutines.forEach { it.join() }
         }.join()
 
-        val cacheFile = File(cacheDir, sut.cacheFileName)
+        Assert.assertEquals(2000, sut.count())
+    }
 
-        val json = cacheFile.readText()
-        val signals = Json.decodeFromString<List<Signal>>(json)
-        Assert.assertEquals(2000, signals.count())
+    @Test
+    fun addAll_appendsAllSignals() = runTest(UnconfinedTestDispatcher()) {
+        val cacheDir = folder.newFolder()
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = UnconfinedTestDispatcher())
+        sut.addAll((1..5).map { makeSignal("type$it") })
+
+        Assert.assertEquals(5, sut.count())
+        val cacheFile = File(cacheDir, sut.cacheFileName)
+        val onDisk = Json.decodeFromString<List<Signal>>(cacheFile.readText())
+        Assert.assertEquals(5, onDisk.count())
+    }
+
+    @Test
+    fun addAll_respectsCacheLimit() = runTest(UnconfinedTestDispatcher()) {
+        val cacheDir = folder.newFolder()
+        val sut = PersistentSignalCache(cacheDir, null, cacheLimit = 3, ioDispatcher = UnconfinedTestDispatcher())
+        sut.addAll((1..7).map { makeSignal("type$it") })
+
+        Assert.assertEquals(3, sut.count())
+        val survivors = sut.empty()
+        Assert.assertEquals("type5", survivors[0].type)
+        Assert.assertEquals("type6", survivors[1].type)
+        Assert.assertEquals("type7", survivors[2].type)
+    }
+
+    @Test
+    fun addAll_acrossExistingQueue_evictsOldest() = runTest(UnconfinedTestDispatcher()) {
+        val cacheDir = folder.newFolder()
+        val sut = PersistentSignalCache(cacheDir, null, cacheLimit = 3, ioDispatcher = UnconfinedTestDispatcher())
+        sut.add(makeSignal("a"))
+        sut.add(makeSignal("b"))
+        sut.addAll(listOf(makeSignal("c"), makeSignal("d"), makeSignal("e")))
+
+        Assert.assertEquals(3, sut.count())
+        val survivors = sut.empty()
+        Assert.assertEquals("c", survivors[0].type)
+        Assert.assertEquals("d", survivors[1].type)
+        Assert.assertEquals("e", survivors[2].type)
+    }
+
+    @Test
+    fun addAll_emptyListIsNoop() = runTest(UnconfinedTestDispatcher()) {
+        val cacheDir = folder.newFolder()
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = UnconfinedTestDispatcher())
+        sut.add(makeSignal("existing"))
+        sut.addAll(emptyList())
+
+        Assert.assertEquals(1, sut.count())
+        val signals = sut.empty()
+        Assert.assertEquals("existing", signals[0].type)
+    }
+
+    @Test
+    fun add_doesNotBlockCallerOnDisk() = runTest {
+        val cacheDir = folder.newFolder()
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = testDispatcher)
+
+        sut.add(makeSignal("type"))
+
+        val cacheFile = File(cacheDir, sut.cacheFileName)
+        Assert.assertFalse("File must not exist before dispatcher runs", cacheFile.exists())
+
+        advanceUntilIdle()
+
+        Assert.assertTrue("File must exist after dispatcher runs", cacheFile.exists())
+        val signals = Json.decodeFromString<List<Signal>>(cacheFile.readText())
+        Assert.assertEquals(1, signals.count())
+    }
+
+    @Test
+    fun rapid_adds_coalesce_to_single_write() = runTest {
+        val cacheDir = folder.newFolder()
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        var dispatchCount = 0
+
+        val countingDispatcher = object : CoroutineDispatcher() {
+            override fun dispatch(context: CoroutineContext, block: Runnable) {
+                dispatchCount++
+                testDispatcher.dispatch(context, block)
+            }
+        }
+
+        val sut = PersistentSignalCache(cacheDir, null, ioDispatcher = countingDispatcher)
+
+        repeat(100) { i ->
+            sut.add(makeSignal("type$i"))
+        }
+
+        advanceUntilIdle()
+
+        val cacheFile = File(cacheDir, sut.cacheFileName)
+        val signals = Json.decodeFromString<List<Signal>>(cacheFile.readText())
+        Assert.assertEquals(100, signals.count())
+        Assert.assertTrue(
+            "Expected fewer than 10 dispatches for 100 adds, got $dispatchCount",
+            dispatchCount < 10,
+        )
     }
 }

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryBroadcastTimerTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryBroadcastTimerTest.kt
@@ -1,0 +1,105 @@
+package com.telemetrydeck.sdk
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import java.lang.ref.WeakReference
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TelemetryBroadcastTimerTest {
+
+    private fun buildTimer(
+        transmitInterval: Long = 10_000L,
+        maxBackoffInterval: Long = 300_000L,
+    ): TelemetryBroadcastTimer {
+        val processor = mockk<TelemetryDeckSignalProcessor>(relaxed = true)
+        val logger = mockk<DebugLogger>(relaxed = true)
+        return TelemetryBroadcastTimer(
+            manager = WeakReference(processor),
+            debugLogger = WeakReference(logger),
+            transmitInterval = transmitInterval,
+            maxBackoffInterval = maxBackoffInterval,
+        )
+    }
+
+    @Test
+    fun backoffGrowsExponentially() {
+        val sut = buildTimer(transmitInterval = 10_000L)
+
+        Assert.assertEquals(10_000L, sut.nextInterval(0))
+        Assert.assertEquals(20_000L, sut.nextInterval(1))
+        Assert.assertEquals(40_000L, sut.nextInterval(2))
+        Assert.assertEquals(80_000L, sut.nextInterval(3))
+    }
+
+    @Test
+    fun backoffCapsAtMax() {
+        val sut = buildTimer(transmitInterval = 10_000L, maxBackoffInterval = 300_000L)
+
+        Assert.assertEquals(300_000L, sut.nextInterval(10))
+    }
+
+    @Test
+    fun successResetsBackoff() {
+        val sut = buildTimer(transmitInterval = 10_000L)
+
+        sut.resetBackoff()
+        Assert.assertEquals(10_000L, sut.nextInterval())
+    }
+
+    @Test
+    fun resetBackoffClearsCounter() {
+        val sut = buildTimer(transmitInterval = 10_000L)
+
+        sut.resetBackoff()
+        Assert.assertEquals(0, sut.currentBackoffFailures())
+        Assert.assertEquals(10_000L, sut.nextInterval())
+    }
+
+    @Test
+    fun clampOnFailureCountAvoidsLongOverflow() {
+        val sut = buildTimer(transmitInterval = 10_000L, maxBackoffInterval = 300_000L)
+
+        Assert.assertEquals(300_000L, sut.nextInterval(Int.MAX_VALUE))
+    }
+
+    @Test
+    fun failedBatchReenqueuesViaAddAll() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val cache = mockk<SignalCache>(relaxed = true)
+        val failedSignals = listOf(
+            Signal(UUID.randomUUID(), "type1", "user", SignalPayload()),
+            Signal(UUID.randomUUID(), "type2", "user", SignalPayload()),
+        )
+        every { cache.empty() } returns failedSignals
+
+        val processor = mockk<TelemetryDeckSignalProcessor>(relaxed = true)
+        every { processor.signalCache } returns cache
+        coEvery { processor.sendAll(any()) } returns Result.failure(Exception("network error"))
+
+        val logger = mockk<DebugLogger>(relaxed = true)
+        val timer = TelemetryBroadcastTimer(
+            manager = WeakReference(processor),
+            debugLogger = WeakReference(logger),
+            transmitInterval = 50L,
+            coroutineContext = testDispatcher,
+        )
+
+        timer.start()
+        advanceTimeBy(200L)
+        timer.stop()
+        advanceUntilIdle()
+
+        verify(atLeast = 1) { cache.addAll(failedSignals) }
+        verify(exactly = 0) { cache.add(any()) }
+    }
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckCompanionTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/TelemetryDeckCompanionTest.kt
@@ -1,0 +1,28 @@
+package com.telemetrydeck.sdk
+
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TelemetryDeckCompanionTest {
+
+    @Before
+    fun setUp() {
+        TelemetryDeck.instance = null
+    }
+
+    @After
+    fun tearDown() {
+        TelemetryDeck.instance = null
+    }
+
+    @Test
+    fun companion_signal_before_init_does_not_throw() {
+        Assert.assertNull(TelemetryDeck.instance)
+        TelemetryDeck.signal("foo")
+    }
+}


### PR DESCRIPTION
This PR addresses a gap identified in https://github.com/TelemetryDeck/SwiftSDK/issues/284 by bounding cache size and adding exponential-backoff retry, plus a few related ergonomics fixes.


- Both `SignalCache` implementations now accept a `cacheLimit`. When the limit is reached, the oldest signals are dropped first (FIFO):

  | Type | `cacheLimit` default | Rationale |
  |------|----------------------|-----------|
  | `MemorySignalCache` | `Int.MAX_VALUE` | In-memory cache is bounded by app lifetime |
  | `PersistentSignalCache` | `10_000` | Bounded persistence on disk |



- Added `flush()` method. Allows clients to reset the backoff counter and immediately attempts to drain the cache. To be used when you want to force delivery under sustained network failure (e.g. before logout)


- Added an error log when TelemetryDeck methods like `signal`, `flush`, `navigate` are called before `TelemetryDeck.start(...)`
