### PR TITLE
Fix a case of missing default parameters when TelemetryDeck is started right after the app is foregrounded

### DIFF
--- a/lib/src/androidTest/java/com/telemetrydeck/sdk/SessionTrackingLaunchEnrichmentTest.kt
+++ b/lib/src/androidTest/java/com/telemetrydeck/sdk/SessionTrackingLaunchEnrichmentTest.kt
@@ -1,0 +1,114 @@
+package com.telemetrydeck.sdk
+
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.telemetrydeck.sdk.params.Calendar
+import com.telemetrydeck.sdk.params.SDK
+import com.telemetrydeck.sdk.signals.Session
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Regression test for the launch-enrichment bug where TelemetryDeck.Session.started was emitted
+ * before enrichment providers (EnvironmentParameterProvider, CalendarParameterProvider, etc.) had
+ * registered, resulting in a launch signal with missing device/SDK/calendar parameters and
+ * sometimes a duplicate signal.
+ *
+ * The fix registers sessionManager LAST inside installProviders(), and removes the explicit
+ * handleOnForeground() call from SessionTrackingSignalProvider.register() — the lifecycle
+ * observer's onStart is the sole trigger.
+ *
+ * This test runs on a real device so ProcessLifecycleOwner transitions naturally when an Activity
+ * is resumed, without any reflection hacks.
+ */
+@RunWith(AndroidJUnit4::class)
+class SessionTrackingLaunchEnrichmentTest {
+
+    private var scenario: ActivityScenario<ComponentActivity>? = null
+    private var sdk: TelemetryDeck? = null
+
+    @After
+    fun cleanup() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            TelemetryDeck.stop()
+            sdk?.let { instance ->
+                instance.broadcastTimer?.stop()
+                for (provider in instance.providers) {
+                    provider.stop()
+                }
+                instance.identityProvider.stop()
+                instance.sessionManager?.stop()
+            }
+            sdk = null
+        }
+        scenario?.close()
+        scenario = null
+        deleteTrackingFile()
+    }
+
+    @Test
+    fun launch_session_signal_contains_enrichment_params_and_is_not_duplicated() {
+        deleteTrackingFile()
+
+        scenario = ActivityScenario.launch(ComponentActivity::class.java)
+        scenario!!.moveToState(Lifecycle.State.RESUMED)
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            assertTrue(
+                "ProcessLifecycleOwner must be at least STARTED before building SDK",
+                ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+            )
+        }
+
+        val cache = MemorySignalCache()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val appContext = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+            sdk = TelemetryDeck.Builder()
+                .appID("32CB6574-6732-4238-879F-582FEBEB6536")
+                .sendNewSessionBeganSignal(true)
+                .signalCache(cache)
+                .build(appContext)
+        }
+
+        val allSignals = cache.empty()
+        val sessionStartedSignals = allSignals.filter { it.type == Session.Started.signalName }
+
+        assertEquals(
+            "Expected exactly one ${Session.Started.signalName} signal, but got ${sessionStartedSignals.size}. All signals: ${allSignals.map { it.type }}",
+            1,
+            sessionStartedSignals.size
+        )
+
+        val launchSignal = sessionStartedSignals.first()
+
+        val sdkVersionEntry = launchSignal.payload.find { it.startsWith("${SDK.Version.paramName}:") }
+        assertNotNull(
+            "Launch session signal must contain '${SDK.Version.paramName}:...' — enrichment providers were not registered before sessionManager",
+            sdkVersionEntry
+        )
+
+        val calendarEntry = launchSignal.payload.find { it.startsWith("${Calendar.DayOfWeek.paramName}:") }
+        assertNotNull(
+            "Launch session signal must contain '${Calendar.DayOfWeek.paramName}:...' — CalendarParameterProvider was not registered before sessionManager",
+            calendarEntry
+        )
+    }
+
+    private fun deleteTrackingFile() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        val file = File(appContext.filesDir, "telemetrydeckstracking")
+        if (file.exists()) {
+            file.delete()
+        }
+    }
+}

--- a/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/TelemetryDeck.kt
@@ -378,13 +378,12 @@ class TelemetryDeck(
     internal var broadcastTimer: TelemetryBroadcastTimer? = null
 
     private fun installProviders(context: Context?) {
-        // session manager must be installed first as some plugins may depend on it
-        sessionManager?.register(context, this)
         for (provider in providers) {
             logger?.debug("Installing provider ${provider::class}.")
             provider.register(context, this)
         }
         identityProvider.register(context, this)
+        sessionManager?.register(context, this)
     }
 
     private fun createSignal(

--- a/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProvider.kt
+++ b/lib/src/main/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProvider.kt
@@ -2,7 +2,6 @@ package com.telemetrydeck.sdk.providers
 
 import android.content.Context
 import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.telemetrydeck.sdk.DateSerializer
@@ -44,11 +43,6 @@ class SessionTrackingSignalProvider: TelemetryDeckSessionManagerProvider, Defaul
         this.manager = WeakReference(client)
         this.appContext = WeakReference(ctx)
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
-        
-        // Check if the process is already in foreground and initialize session tracking immediately
-        if (ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-            handleOnForeground()
-        }
     }
 
     @Synchronized

--- a/lib/src/test/java/com/telemetrydeck/sdk/providers/SessionTrackingRegressionTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/providers/SessionTrackingRegressionTest.kt
@@ -1,0 +1,95 @@
+package com.telemetrydeck.sdk.providers
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.telemetrydeck.sdk.TelemetryDeck
+import com.telemetrydeck.sdk.signals.Session
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+/**
+ * Regression guard for the launch-session ordering bug:
+ *
+ * When the process lifecycle is already at STARTED when TelemetryDeck.build() runs,
+ * SessionTrackingSignalProvider.register() -> ProcessLifecycleOwner.addObserver() dispatches
+ * a synchronous catch-up onStart() -> Session.started is emitted at that point. The fix ensures
+ * all enrichment providers (EnvironmentParameterProvider, CalendarParameterProvider, etc.) are
+ * registered before sessionManager.register() runs, so the signal is fully enriched and emitted
+ * exactly once.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class SessionTrackingRegressionTest {
+
+    @Before
+    fun setUp() {
+        TelemetryDeck.instance = null
+    }
+
+    @After
+    fun tearDown() {
+        TelemetryDeck.stop()
+        TelemetryDeck.instance = null
+        // Reset ProcessLifecycleOwner to below STARTED so tests sharing this sandbox are not
+        // affected. activityStopped$lifecycle_process() mirrors what happens when the last
+        // activity stops, transitioning the registry back toward CREATED.
+        val processOwner = ProcessLifecycleOwner.get()
+        processOwner.javaClass
+            .getMethod("activityStopped\$lifecycle_process")
+            .invoke(processOwner)
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    fun launch_sessionStarted_is_enriched_and_single_when_process_already_started() {
+        // Advance ProcessLifecycleOwner to STARTED before build() is called, reproducing the
+        // scenario where an app's process is already foregrounded when TelemetryDeck initializes.
+        // activityStarted$lifecycle_process() is the exact method that ReportFragment.onStart()
+        // and the ActivityLifecycleCallbacks in ProcessLifecycleOwner.attach() invoke in
+        // production. It is public at the JVM level (Kotlin-module visibility only prevents
+        // cross-module calls at the Kotlin compiler level).
+        val processOwner = ProcessLifecycleOwner.get()
+        processOwner.javaClass
+            .getMethod("activityStarted\$lifecycle_process")
+            .invoke(processOwner)
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        Assert.assertTrue(
+            "ProcessLifecycleOwner must reach STARTED before build() for this test to be meaningful",
+            processOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+        )
+
+        val manager = TelemetryDeck.Builder()
+            .appID("32CB6574-6732-4238-879F-582FEBEB6536")
+            .sendNewSessionBeganSignal(true)
+            .build(RuntimeEnvironment.getApplication())
+
+        Shadows.shadowOf(android.os.Looper.getMainLooper()).idle()
+
+        val signals = manager.cache?.empty() ?: emptyList()
+        val sessionStartedSignals = signals.filter { it.type == Session.Started.signalName }
+
+        Assert.assertEquals(
+            "Expected exactly one Session.started signal, got ${sessionStartedSignals.size}",
+            1,
+            sessionStartedSignals.size
+        )
+
+        val signal = sessionStartedSignals.first()
+        Assert.assertTrue(
+            "Session.started must carry TelemetryDeck.SDK.version from EnvironmentParameterProvider",
+            signal.payload.any { it.startsWith("TelemetryDeck.SDK.version:") }
+        )
+        Assert.assertTrue(
+            "Session.started must carry TelemetryDeck.Calendar.dayOfWeek from CalendarParameterProvider",
+            signal.payload.any { it.startsWith("TelemetryDeck.Calendar.dayOfWeek:") }
+        )
+    }
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProviderTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProviderTest.kt
@@ -1,0 +1,82 @@
+package com.telemetrydeck.sdk.providers
+
+import com.telemetrydeck.sdk.TelemetryDeck
+import com.telemetrydeck.sdk.signals.Session
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class SessionTrackingSignalProviderTest {
+
+    // Robolectric unit tests leave ProcessLifecycleOwner at INITIALIZED (no activity running),
+    // so addObserver catch-up does not fire onStart() automatically. Tests drive foreground
+    // transitions by calling handleOnForeground() directly, which is the same code path invoked
+    // by onStart(). The regression guard for the double-fire (point 4 in the spec) relies on the
+    // process already being STARTED when register() runs — that path requires an instrumented
+    // (device/emulator) test and is not covered here.
+
+    @Test
+    fun sessionStarted_emits_exactly_one_signal_when_foreground_triggered_after_registration() {
+        val context = RuntimeEnvironment.getApplication()
+        val manager = TelemetryDeck.Builder()
+            .appID("32CB6574-6732-4238-879F-582FEBEB6536")
+            .sendNewSessionBeganSignal(true)
+            .build(context)
+
+        val sessionProvider = manager.sessionManager as? SessionTrackingSignalProvider
+        Assert.assertNotNull(sessionProvider)
+        sessionProvider!!.handleOnForeground()
+
+        val signals = manager.cache?.empty() ?: emptyList()
+        val sessionStartedSignals = signals.filter { it.type == Session.Started.signalName }
+
+        Assert.assertEquals(1, sessionStartedSignals.size)
+    }
+
+    @Test
+    fun sessionStarted_payload_contains_sdk_version_and_calendar_enrichment() {
+        val context = RuntimeEnvironment.getApplication()
+        val manager = TelemetryDeck.Builder()
+            .appID("32CB6574-6732-4238-879F-582FEBEB6536")
+            .sendNewSessionBeganSignal(true)
+            .build(context)
+
+        val sessionProvider = manager.sessionManager as? SessionTrackingSignalProvider
+        Assert.assertNotNull(sessionProvider)
+        sessionProvider!!.handleOnForeground()
+
+        val signals = manager.cache?.empty() ?: emptyList()
+        val sessionStartedSignal = signals.firstOrNull { it.type == Session.Started.signalName }
+
+        Assert.assertNotNull(sessionStartedSignal)
+        Assert.assertTrue(
+            sessionStartedSignal?.payload?.any { it.startsWith("TelemetryDeck.SDK.version:") } == true
+        )
+        Assert.assertTrue(
+            sessionStartedSignal?.payload?.any { it.startsWith("TelemetryDeck.Calendar.dayOfWeek:") } == true
+        )
+    }
+
+    @Test
+    fun sessionStarted_not_emitted_when_disabled() {
+        val context = RuntimeEnvironment.getApplication()
+        val manager = TelemetryDeck.Builder()
+            .appID("32CB6574-6732-4238-879F-582FEBEB6536")
+            .sendNewSessionBeganSignal(false)
+            .build(context)
+
+        val sessionProvider = manager.sessionManager as? SessionTrackingSignalProvider
+        Assert.assertNotNull(sessionProvider)
+        sessionProvider!!.handleOnForeground()
+
+        val signals = manager.cache?.empty() ?: emptyList()
+        val sessionStartedSignals = signals.filter { it.type == Session.Started.signalName }
+
+        Assert.assertEquals(0, sessionStartedSignals.size)
+    }
+}

--- a/lib/src/test/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProviderTest.kt
+++ b/lib/src/test/java/com/telemetrydeck/sdk/providers/SessionTrackingSignalProviderTest.kt
@@ -13,13 +13,6 @@ import org.robolectric.annotation.Config
 @Config(sdk = [28])
 class SessionTrackingSignalProviderTest {
 
-    // Robolectric unit tests leave ProcessLifecycleOwner at INITIALIZED (no activity running),
-    // so addObserver catch-up does not fire onStart() automatically. Tests drive foreground
-    // transitions by calling handleOnForeground() directly, which is the same code path invoked
-    // by onStart(). The regression guard for the double-fire (point 4 in the spec) relies on the
-    // process already being STARTED when register() runs — that path requires an instrumented
-    // (device/emulator) test and is not covered here.
-
     @Test
     fun sessionStarted_emits_exactly_one_signal_when_foreground_triggered_after_registration() {
         val context = RuntimeEnvironment.getApplication()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
     }
 }
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
This fixes https://github.com/TelemetryDeck/FlutterSDK/issues/52